### PR TITLE
fix(release-notes): authenticate GitHub fetch to keep TOC populated

### DIFF
--- a/content/release-notes.mdx
+++ b/content/release-notes.mdx
@@ -9,8 +9,22 @@ import { ReleaseNotes } from '@/components/ReleaseNotes/ReleaseNotes';
 export const metadata = {
     toc: await (async () => {
         try {
+            // Pass `GITHUB_TOKEN` whenever it's available. Without it
+            // the build-time fetch is unauthenticated and shares the
+            // 60 req/hr GitHub limit per IP — on Vercel the build IP
+            // is pooled across customers so this quota gets eaten by
+            // unrelated builds, the request returns a 403 rate-limit
+            // body instead of an array, and the TOC silently degrades
+            // to "Release Notes" only. Locally the IP has its own
+            // 60/hr so it usually works without the header — which
+            // hides the bug during dev. With the token the user's
+            // 5000/hr quota applies and rebuilds are reliable.
+            const token = process.env.GITHUB_TOKEN;
             const res = await fetch(
-                'https://api.github.com/repos/gfazioli/findergit-website/releases?per_page=10'
+                'https://api.github.com/repos/gfazioli/findergit-website/releases?per_page=10',
+                token
+                    ? { headers: { Authorization: `Bearer ${token}` } }
+                    : undefined
             );
             const releases = await res.json();
             if (!Array.isArray(releases)) return [];


### PR DESCRIPTION
## Symptom

The right-hand **On This Page** panel at [findergit.app/docs/release-notes](https://findergit.app/docs/release-notes) was showing only a single **Release Notes** entry instead of the per-version list (v0.6.0, v0.5.0, …). Visible on production after the v0.6.0 deploy; **not reproducible locally** — running `yarn dev` showed the full TOC. That mismatch was the giveaway.

## Root cause

`content/release-notes.mdx` builds its TOC at build time via `metadata.toc`, which fetches the latest 10 GitHub releases:

```js
const res = await fetch(
  'https://api.github.com/repos/gfazioli/findergit-website/releases?per_page=10'
);
```

The fetch is **unauthenticated**. Locally that's fine — the dev machine's IP has its own 60 req/hr GitHub quota that's hard to exhaust. On Vercel the build runs from a **pooled IP shared across many customers**, and that pool burns through 60 req/hr regularly. When the limit hits, GitHub returns a JSON body that's not an array, the existing `Array.isArray` guard returns `[]`, and the page silently falls back to the bare `## Release Notes` H2.

## Fix

Pass the `GITHUB_TOKEN` env var (already provisioned for the runtime `/api/github-releases` proxy) when it's present:

```js
const token = process.env.GITHUB_TOKEN;
const res = await fetch(url,
  token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
);
```

With the token the user's **5000 req/hr** quota applies. Behaviour without the token is unchanged (graceful degrade to empty TOC), so this can't break local-dev setups that haven't configured the token.

## Verification

- [ ] On Vercel, after this PR merges and the production rebuild completes, `/docs/release-notes` shows v0.6.0, v0.5.0, v0.4.1, … in the right-hand TOC
- [ ] `yarn dev` still works (tested — TOC populated as before)
- [ ] `yarn test` passes (typecheck, lint, jest — all green)

## Notes

`GITHUB_TOKEN` is already required on Vercel per `findergit-website/CLAUDE.md` for the runtime proxy. No new env var to provision.