### PR TITLE
fix(footer): add Netfox to the ecosystem list

### DIFF
--- a/components/MantineFooter/links/ecosystem.ts
+++ b/components/MantineFooter/links/ecosystem.ts
@@ -6,6 +6,12 @@ export const ecosystem = [
     newWindow: true,
   },
   {
+    key: 'netfox',
+    title: 'Netfox',
+    href: 'https://netfox.app',
+    newWindow: true,
+  },
+  {
     key: 'octoscope',
     title: 'Octoscope',
     href: 'https://gfazioli.github.io/octoscope/',


### PR DESCRIPTION
## Summary

The footer's ecosystem column lists the sibling projects (Mantine Extensions, Octoscope, WP Bones) but was missing **Netfox** — the macOS app whose website lives at https://netfox.app. Add it between Mantine Extensions and Octoscope to keep the column alphabetical, mirroring the FinderGit entry that already exists on netfox-website's footer.

## Test plan

- [ ] After Vercel deploys, the footer's *Ecosystem* column shows Netfox → click → lands on https://netfox.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)