### PR TITLE
chore: block AI scrapers + cache github-releases route

### DIFF
--- a/app/api/github-releases/route.ts
+++ b/app/api/github-releases/route.ts
@@ -14,30 +14,59 @@ export async function GET(request: Request) {
       return Response.json({ error: 'Bots are not allowed' }, { status: 403 });
     }
 
-    const headers: Record<string, string> = {
+    const url = `${config.gitHub.releasesUrl}?per_page=${config.releaseNotes.maxReleases}`;
+    const baseHeaders: Record<string, string> = {
       Accept: 'application/vnd.github+json',
+      'User-Agent': 'findergit-website',
     };
-    // Use a token if configured (Vercel env var GITHUB_TOKEN). Authenticated
-    // requests get 5000/hour instead of 60/hour per IP, which matters on
-    // shared IPs like Vercel's.
+
+    // Try authenticated first if a token is configured (5000 req/hour vs 60/hour).
+    // If the token is invalid/expired (401) or rejected by org policy (403, e.g.
+    // fine-grained tokens with too-long lifetime), retry unauthenticated instead
+    // of failing — public releases are readable without auth.
+    const fetchOptions = { next: { revalidate: 3600 } };
+    let response: Response;
     if (process.env.GITHUB_TOKEN) {
-      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+      response = await fetch(url, {
+        ...fetchOptions,
+        headers: { ...baseHeaders, Authorization: `Bearer ${process.env.GITHUB_TOKEN}` },
+      });
+      if (response.status === 401 || response.status === 403) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `GITHUB_TOKEN returned ${response.status} — falling back to unauthenticated fetch`
+        );
+        response = await fetch(url, { ...fetchOptions, headers: baseHeaders });
+      }
+    } else {
+      response = await fetch(url, { ...fetchOptions, headers: baseHeaders });
     }
 
-    const response = await fetch(
-      `${config.gitHub.releasesUrl}?per_page=${config.releaseNotes.maxReleases}`,
-      { headers }
-    );
-
     if (!response.ok) {
+      const bodyText = await response.text();
+      const rateRemaining = response.headers.get('x-ratelimit-remaining');
+      const rateReset = response.headers.get('x-ratelimit-reset');
       // eslint-disable-next-line no-console
-      console.error('Error fetching releases:', response.statusText);
+      console.error('[github-releases] non-OK response', {
+        status: response.status,
+        statusText: response.statusText,
+        rateRemaining,
+        rateReset,
+        body: bodyText.slice(0, 300),
+      });
       return Response.json(response.statusText, { status: response.status });
     }
 
     const releases = await response.json();
 
-    return Response.json({ releases, status: 'ok' });
+    return Response.json(
+      { releases, status: 'ok' },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+        },
+      }
+    );
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.error('Error checking user agent:', error);

--- a/app/api/github-releases/route.ts
+++ b/app/api/github-releases/route.ts
@@ -21,22 +21,36 @@ export async function GET(request: Request) {
     };
 
     // Try authenticated first if a token is configured (5000 req/hour vs 60/hour).
-    // If the token is invalid/expired (401) or rejected by org policy (403, e.g.
-    // fine-grained tokens with too-long lifetime), retry unauthenticated instead
-    // of failing — public releases are readable without auth.
-    const fetchOptions = { next: { revalidate: 3600 } };
+    // If the token is invalid (401) or rejected by org policy (403 *not* due to
+    // rate limiting), retry unauthenticated — public releases are readable
+    // without auth. We do NOT fall back on a rate-limited 403, since that just
+    // consumes another quota slot and amplifies throttling.
+    const FETCH_TIMEOUT_MS = 10_000;
+    const fetchOptions = {
+      next: { revalidate: 3600 },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    };
     let response: Response;
     if (process.env.GITHUB_TOKEN) {
       response = await fetch(url, {
         ...fetchOptions,
         headers: { ...baseHeaders, Authorization: `Bearer ${process.env.GITHUB_TOKEN}` },
       });
-      if (response.status === 401 || response.status === 403) {
+      const rateRemaining = response.headers.get('x-ratelimit-remaining');
+      const shouldFallback =
+        response.status === 401 || (response.status === 403 && rateRemaining !== '0');
+      if (shouldFallback) {
+        // Drain the body to release the undici connection before refetching.
+        await response.text();
         // eslint-disable-next-line no-console
         console.warn(
           `GITHUB_TOKEN returned ${response.status} — falling back to unauthenticated fetch`
         );
-        response = await fetch(url, { ...fetchOptions, headers: baseHeaders });
+        response = await fetch(url, {
+          ...fetchOptions,
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+          headers: baseHeaders,
+        });
       }
     } else {
       response = await fetch(url, { ...fetchOptions, headers: baseHeaders });
@@ -54,7 +68,10 @@ export async function GET(request: Request) {
         rateReset,
         body: bodyText.slice(0, 300),
       });
-      return Response.json(response.statusText, { status: response.status });
+      return Response.json(
+        { error: response.statusText || 'GitHub releases fetch failed' },
+        { status: response.status }
+      );
     }
 
     const releases = await response.json();
@@ -64,6 +81,7 @@ export async function GET(request: Request) {
       {
         headers: {
           'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+          Vary: 'User-Agent',
         },
       }
     );

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,97 @@
+# https://findergit.app/robots.txt
+#
+# Search engines are welcome.
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Slurp
+Allow: /
+
+User-agent: Baiduspider
+Allow: /
+
+User-agent: YandexBot
+Allow: /
+
+# Block AI training / scraping crawlers (high CDN cost, no SEO value)
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Perplexity-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Meta-ExternalFetcher
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: DuckAssistBot
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: omgilibot
+Disallow: /
+
+# Default rule for everything else
+User-agent: *
+Allow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -68,6 +68,12 @@ Disallow: /
 User-agent: FacebookBot
 Disallow: /
 
+User-agent: facebookexternalhit
+Disallow: /
+
+User-agent: Facebot
+Disallow: /
+
 User-agent: ImagesiftBot
 Disallow: /
 


### PR DESCRIPTION
## Summary

Replica le difese anti-AI-bot già applicate su [wpbones-website-docs](https://github.com/wpbones/website-docs/pull/40) per ridurre ISR Read Units su Vercel.

## Changes

- **public/robots.txt** (new): Disallow esplicito per ~24 bot AI/scraper.
- **app/api/github-releases/route.ts**: `next: { revalidate: 3600 }` + `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400` + User-Agent + 401/403 unauth fallback.

## Test plan
- [ ] Vercel preview deploy
- [ ] `curl https://<preview>/api/github-releases -I` → header `Cache-Control` presente
- [ ] `/robots.txt` raggiungibile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved fetching of GitHub release data with retry fallback, request timeout, structured error handling, and stronger caching/validation headers to reduce latency and improve reliability.

* **Chores**
  * Added robots.txt rules to allow major search engines while restricting a set of automated/scraping agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->