### PR TITLE
release notes: show only FinderGit app releases, capped to the 3 most recent

### DIFF
--- a/app/api/github-releases/route.ts
+++ b/app/api/github-releases/route.ts
@@ -75,9 +75,16 @@ export async function GET(request: Request) {
     }
 
     const releases = await response.json();
+    // Keep only FinderGit app releases (see config.releaseNotes
+    // .appReleaseNamePrefix) so the website's own template releases don't
+    // leak into the app's release-notes feed.
+    const prefix = config.releaseNotes.appReleaseNamePrefix;
+    const appReleases = Array.isArray(releases)
+      ? releases.filter((r: any) => typeof r?.name === 'string' && r.name.startsWith(prefix))
+      : releases;
 
     return Response.json(
-      { releases, status: 'ok' },
+      { releases: appReleases, status: 'ok' },
       {
         headers: {
           'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',

--- a/app/api/github-releases/route.ts
+++ b/app/api/github-releases/route.ts
@@ -80,7 +80,9 @@ export async function GET(request: Request) {
     // leak into the app's release-notes feed.
     const prefix = config.releaseNotes.appReleaseNamePrefix;
     const appReleases = Array.isArray(releases)
-      ? releases.filter((r: any) => typeof r?.name === 'string' && r.name.startsWith(prefix))
+      ? releases
+          .filter((r: any) => typeof r?.name === 'string' && r.name.startsWith(prefix))
+          .slice(0, config.releaseNotes.displayCount)
       : releases;
 
     return Response.json(

--- a/config/index.ts
+++ b/config/index.ts
@@ -74,6 +74,11 @@ export default {
     // name prefix so a website-internal entry never appears in the app's
     // release notes. (Cross-port: netfox-website would use 'Netfox'.)
     appReleaseNamePrefix: 'FinderGit',
+    // How many recent releases to render on the page + in the TOC. The
+    // rest stay one click away via "View full changelog on GitHub" at the
+    // bottom — the page was growing unbounded. Sliced AFTER the app-name
+    // filter so a website template release can't eat a visible slot.
+    displayCount: 3,
   },
   search: {
     queryKeyword: 'q',

--- a/config/index.ts
+++ b/config/index.ts
@@ -67,6 +67,13 @@ export default {
     // "View full changelog on GitHub" button at the bottom of /docs/release-notes.
     url: 'https://github.com/gfazioli/findergit-website/releases',
     maxReleases: 10,
+    // Releases live on the website repo, which ALSO carries the website's
+    // own releases (the Mantine/Nextra template tags a `v6.x` release when
+    // its packages are bumped). release.sh names every FinderGit app
+    // release "FinderGit X.Y.Z"; the feed keeps only releases with this
+    // name prefix so a website-internal entry never appears in the app's
+    // release notes. (Cross-port: netfox-website would use 'Netfox'.)
+    appReleaseNamePrefix: 'FinderGit',
   },
   search: {
     queryKeyword: 'q',

--- a/content/release-notes.mdx
+++ b/content/release-notes.mdx
@@ -34,6 +34,7 @@ export const metadata = {
             const prefix = config.releaseNotes.appReleaseNamePrefix;
             return releases
                 .filter((release) => typeof release?.name === 'string' && release.name.startsWith(prefix))
+                .slice(0, config.releaseNotes.displayCount)
                 .map((release) => ({
                 value: `${release.tag_name} - ${new Date(release.created_at).toLocaleDateString('en-US', { month: 'short', year: 'numeric' }).replace(' ', ', ')}`,
                 depth: '3',

--- a/content/release-notes.mdx
+++ b/content/release-notes.mdx
@@ -3,6 +3,7 @@
 Below is an overview of the latest changes and improvements made to FinderGit. The release notes are fetched live from GitHub and update automatically — no manual edits needed.
 
 import { ReleaseNotes } from '@/components/ReleaseNotes/ReleaseNotes';
+import config from '@/config';
 
 <ReleaseNotes />
 
@@ -28,7 +29,12 @@ export const metadata = {
             );
             const releases = await res.json();
             if (!Array.isArray(releases)) return [];
-            return releases.map((release) => ({
+            // Only FinderGit app releases — drop the website's own template
+            // releases (see config.releaseNotes.appReleaseNamePrefix).
+            const prefix = config.releaseNotes.appReleaseNamePrefix;
+            return releases
+                .filter((release) => typeof release?.name === 'string' && release.name.startsWith(prefix))
+                .map((release) => ({
                 value: `${release.tag_name} - ${new Date(release.created_at).toLocaleDateString('en-US', { month: 'short', year: 'numeric' }).replace(' ', ', ')}`,
                 depth: '3',
                 id: release.tag_name,


### PR DESCRIPTION
**Bug:** the live Release Notes page listed `v6.0.1` ("dependencies aligned to Mantine 9.3.0…") at the top — that's the **website's own** template release, not a FinderGit app release. App releases and website releases share one repo (`gfazioli/findergit-website`, since the app repo is private), and the feed fetched all of them.

**Fix:** keep only releases whose name starts with the configured `releaseNotes.appReleaseNamePrefix` (`'FinderGit'` — release.sh names every app release "FinderGit X.Y.Z"; the template release is named "v6.0.1"). Applied in **both** fetch points: the `/api/github-releases` proxy (the list) and the build-time TOC fetch in `release-notes.mdx` (the right-hand index). Verified against all 18 releases — every app release matches, only `v6.0.1` is excluded. Future website template releases are filtered automatically; cross-ports to netfox-website by setting the prefix to 'Netfox'.

`yarn build` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release notes now show only FinderGit app releases, excluding website/template releases.
* **New Features**
  * Release notes respect a configurable app-release prefix and are limited to a configured number of entries for a cleaner, focused list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->