### PR TITLE
fix: center the footer colophon

### DIFF
--- a/components/MantineFooter/MantineFooter.tsx
+++ b/components/MantineFooter/MantineFooter.tsx
@@ -196,8 +196,8 @@ export const MantineFooter = () => {
 
         <Divider my={16} className={classes.lastDivider} />
 
-        <Group justify="flex-end">
-          <Group justify="right">
+        <Group justify="center">
+          <Group justify="center">
             <Text fz={12} inline>
               Made with ❤️ by{' '}
               <Anchor fz={13} href="https://gfazioli.github.io/">


### PR DESCRIPTION
The footer's "Made with ❤️ · Hosted on · Built with" row was right-aligned; centered it to sit under the centered sponsors block. Trivial alignment change (`justify="flex-end"`/`"right"` → `"center"`). Same fix applied on netfox-website. Build: green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Centered the footer attribution section layout for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->