### PR TITLE
docs: post-0.11.0 fixes — unstage screenshot placement + FAQ refresh

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -1,18 +1,33 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { Accordion, Anchor, Text } from '@mantine/core';
 
-const faqItems = [
+const faqItems: { value: string; question: string; answer: ReactNode }[] = [
   {
     value: 'what',
     question: 'What is FinderGit?',
     answer:
-      'FinderGit is a native macOS application that works as a Git-aware file browser. Think of it as Finder\u2019s list view, but with Git status, branch info, inline diffs, and commit/push/pull actions built in.',
+      'FinderGit is a native macOS application that works as a Git-aware file browser. Think of it as Finder’s list view, but with Git status, branch info, inline diffs, and commit/push/pull actions built in.',
   },
   {
     value: 'free',
     question: 'Is FinderGit free?',
-    answer: 'sponsor',
+    answer: (
+      <>
+        Yes, FinderGit is currently free. If you find it useful, consider{' '}
+        <Anchor href="https://github.com/sponsors/gfazioli" size="sm">
+          sponsoring the project
+        </Anchor>
+        .
+      </>
+    ),
+  },
+  {
+    value: 'appstore',
+    question: 'Is FinderGit on the App Store? How do updates work?',
+    answer:
+      'FinderGit is distributed directly from findergit.app as a signed and notarized DMG — it’s not on the App Store. Updates are automatic: the app checks for new releases and installs them in place, so you’re always one click away from the latest version.',
   },
   {
     value: 'macos',
@@ -24,7 +39,7 @@ const faqItems = [
     value: 'replace',
     question: 'Does FinderGit replace my Git client?',
     answer:
-      'Not entirely. FinderGit is great for everyday operations (status check, commit, push, pull) across many repos at once. For advanced workflows (interactive rebase, cherry-pick, complex merges), you\u2019ll still want a full Git client or the terminal.',
+      'Not entirely — but it covers more ground every release. Day-to-day work happens without leaving the app: status across many repos at once, stage/unstage and discard, commit (with AI-generated messages), push/pull/fetch, branch switching, and keeping forks in sync with their upstream. For advanced surgery (interactive rebase, cherry-pick, complex merges) you’ll still want a full Git client or the terminal.',
   },
   {
     value: 'detect',
@@ -36,7 +51,38 @@ const faqItems = [
     value: 'modify',
     question: 'Does FinderGit modify my repositories?',
     answer:
-      'Only when you explicitly perform an action (commit, push, pull, stage, etc.). FinderGit reads your repository state via git status and git diff \u2014 it never modifies anything without your command.',
+      'Only when you explicitly perform an action (commit, push, pull, stage, etc.). FinderGit reads your repository state via git status and git diff — it never modifies anything without your command.',
+  },
+  {
+    value: 'trust',
+    question: 'Is it safe to open repositories I don’t fully trust?',
+    answer: (
+      <>
+        That&apos;s what{' '}
+        <Anchor href="/docs/repo-trust" size="sm">
+          Repo Trust
+        </Anchor>{' '}
+        is for. FinderGit scans each repository&apos;s auto-run surface — hooks and
+        configuration that could execute code when you open, build, or install — without ever
+        running any of it. Repos with findings are flagged in the list, and you get an alert when
+        that surface changes after a pull.
+      </>
+    ),
+  },
+  {
+    value: 'privacy',
+    question: 'Does FinderGit send my data anywhere?',
+    answer: (
+      <>
+        No telemetry, ever. GitHub data (issues, pull requests, stars, fork status) is fetched
+        directly from api.github.com using your own credentials. The only exception is the optional{' '}
+        <Anchor href="/docs/ai-commit-messages" size="sm">
+          AI commit message
+        </Anchor>{' '}
+        feature: when you click ✨ AI, your staged diff is sent to generate the message —
+        nothing is stored, and nothing is sent unless you ask.
+      </>
+    ),
   },
   {
     value: 'live',
@@ -47,12 +93,36 @@ const faqItems = [
   {
     value: 'bug',
     question: 'I found a bug. How do I report it?',
-    answer: 'bug-report',
+    answer: (
+      <>
+        Please open a{' '}
+        <Anchor
+          href="https://github.com/gfazioli/findergit-website/issues/new?template=bug_report.yml"
+          size="sm"
+        >
+          Bug Report
+        </Anchor>{' '}
+        on GitHub. Include your FinderGit version, macOS version, and steps to reproduce the issue.
+        Screenshots are very helpful!
+      </>
+    ),
   },
   {
     value: 'feature',
     question: 'I have an idea for a new feature. Where can I suggest it?',
-    answer: 'feature-request',
+    answer: (
+      <>
+        We&apos;d love to hear your ideas! Open a{' '}
+        <Anchor
+          href="https://github.com/gfazioli/findergit-website/issues/new?template=feature_request.yml"
+          size="sm"
+        >
+          Feature Request
+        </Anchor>{' '}
+        on GitHub and describe what you&apos;d like FinderGit to do. The more detail you provide,
+        the better we can evaluate and prioritize it.
+      </>
+    ),
   },
 ];
 
@@ -63,43 +133,9 @@ export function FAQ() {
         <Accordion.Item key={item.value} value={item.value}>
           <Accordion.Control>{item.question}</Accordion.Control>
           <Accordion.Panel>
-            {item.answer === 'sponsor' ? (
-              <Text c="dimmed" size="sm">
-                Yes, FinderGit is currently free. If you find it useful, consider{' '}
-                <Anchor href="https://github.com/sponsors/gfazioli" size="sm">
-                  sponsoring the project
-                </Anchor>
-                .
-              </Text>
-            ) : item.answer === 'bug-report' ? (
-              <Text c="dimmed" size="sm">
-                Please open a{' '}
-                <Anchor
-                  href="https://github.com/gfazioli/findergit-website/issues/new?template=bug_report.yml"
-                  size="sm"
-                >
-                  Bug Report
-                </Anchor>{' '}
-                on GitHub. Include your FinderGit version, macOS version, and steps to reproduce the
-                issue. Screenshots are very helpful!
-              </Text>
-            ) : item.answer === 'feature-request' ? (
-              <Text c="dimmed" size="sm">
-                We&apos;d love to hear your ideas! Open a{' '}
-                <Anchor
-                  href="https://github.com/gfazioli/findergit-website/issues/new?template=feature_request.yml"
-                  size="sm"
-                >
-                  Feature Request
-                </Anchor>{' '}
-                on GitHub and describe what you&apos;d like FinderGit to do. The more detail you
-                provide, the better we can evaluate and prioritize it.
-              </Text>
-            ) : (
-              <Text c="dimmed" size="sm">
-                {item.answer}
-              </Text>
-            )}
+            <Text c="dimmed" size="sm">
+              {item.answer}
+            </Text>
           </Accordion.Panel>
         </Accordion.Item>
       ))}

--- a/content/detail-panel.mdx
+++ b/content/detail-panel.mdx
@@ -51,6 +51,8 @@ This is where the working-tree affordances live. The Unstage tab holds:
 
 This was previously folded into Overview; splitting it out keeps the informational and operational concerns separate.
 
+![Unstage tab with changes list, inline diff, and the commit form](/screenshot-detail-unstage.png)
+
 ### Discard changes
 
 Every unstaged row also carries a red **Discard**, and the section header a **Discard All** — the complement to Stage/Unstage when you want changes *gone* rather than staged:
@@ -61,8 +63,6 @@ Every unstaged row also carries a red **Discard**, and the section header a **Di
 Both run behind a confirmation that states exactly what will happen, including the file count for Discard All. Discarding is destructive by nature; the Trash routing for untracked files is the safety net.
 
 ![Unstage tab with three unstaged changes — a red Discard on each row and Discard All next to Stage All in the header](/screenshot-discard.png)
-
-![Unstage tab with changes list, inline diff, and the commit form](/screenshot-detail-unstage.png)
 
 ## Commits
 


### PR DESCRIPTION
Two follow-ups from the post-release visual review on the dev server.

1. **Unstage screenshot placement** — adding the *Discard changes* subsection (#17) left the original Unstage screenshot stranded below it; moved back under the Unstage intro where it belongs.
2. **FAQ refresh** — the FAQ predated v0.9–0.11:
   - *Does FinderGit replace my Git client?* now reflects current capabilities (branch switching, fork sync, discard, AI commit) while keeping the honest caveat.
   - Three new entries: **App Store / updates** (signed+notarized DMG, automatic in-app updates), **opening untrusted repos** (→ Repo Trust), **data/privacy** (no telemetry, direct api.github.com, AI diff sent only on demand).
   - Internal refactor: `answer` is now `ReactNode` — drops the fragile sentinel-string switch for real JSX links.

Verified on the dev server (visual review done); `yarn typecheck` + `yarn lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Repositioned screenshot in Unstage section for improved visual navigation.

* **Updates**
  * Enhanced FAQ items with rich text formatting and interactive links throughout.
  * Updated FAQ answer text with revised and clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->