### PR TITLE
docs: feature Repo Trust supply-chain worm detection (0.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ FinderGit is a native macOS app that combines file browsing with Git intelligenc
 - **Auto-fetch** — optional background `git fetch` at a user-chosen interval to keep the ahead/behind counter fresh
 - **Diff viewer** — click any modified file to see a colored inline diff
 - **Git actions** — stage, unstage, commit, push, pull, fetch, branch switch, all from the UI
+- **Repo Trust — supply-chain safety** — surface a repo's *auto-run surface* (editor tasks, AI-agent configs, dev-container and npm hooks) and get alerted when it changes after a pull. FinderGit also detects the committed **dropper** behind supply-chain worms like **Shai-Hulud / Miasma** — the obfuscated `.github/setup.js`-style payload — across *every* branch, not just the checkout, and never runs anything it finds. When a repo looks compromised it shows an incident runbook: revoke the OAuth authorization, then reset (not revert) the infected branches
+- **Repo Maintenance** — a per-repo disk-usage breakdown and one-click cleanup (Optimize / Deep Clean) to reclaim Git space, with a sortable Size column in the browser
 - **Native Markdown preview** — press Space on any `.md` file for a rendered preview
 - **Smart context menus** — adapts to whether you're on a regular file, a tracked file, or a repository
 - **Multiple root folders** — add as many as you want; drop folders from the macOS Finder into the sidebar to add them as roots
@@ -57,6 +59,7 @@ After downloading, open the DMG and drag FinderGit into your Applications folder
   xcode-select --install
   sudo xcodebuild -license
   ```
+- Repositories that use [Git LFS](https://git-lfs.com) need `git-lfs` installed (`brew install git-lfs && git lfs install`). FinderGit detects when it's missing and tells you exactly how to fix it instead of failing silently.
 
 ## Documentation
 

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -276,7 +276,7 @@ const features = [
     icon: IconShieldHalfFilled,
     title: 'Repo Trust',
     description:
-      'Surface the hooks that run code automatically in any repo — and get alerted when they change after a pull.',
+      'Catch the obfuscated dropper behind supply-chain worms like Shai-Hulud / Miasma — across every branch — plus the hooks that auto-run a repo, with an alert when they change after a pull.',
     color: 'indigo',
     href: '/docs/repo-trust',
     badge: 'New',
@@ -528,8 +528,8 @@ export function Welcome() {
             <FeatureRow
               icon={IconShieldHalfFilled}
               iconColor="indigo"
-              title="Know what a repo runs before you trust it"
-              description="Cloning or pulling a repo can quietly arm it to run code — on folder open, on agent load, on npm install. The Trust tab surfaces that auto-run surface in plain language, shows you exactly what each hook runs, and flags it in the browser when it changes after a pull. It only ever reads — FinderGit never executes anything it finds."
+              title="Catch a supply-chain worm before it runs"
+              description="Cloning or pulling a repo can quietly arm it to run code — on folder open, on agent load, on npm install. Repo Trust surfaces that auto-run surface in plain language and detects the obfuscated dropper behind supply-chain worms like Shai-Hulud / Miasma — across every branch, not just the one you checked out. It flags changes after a pull, walks you through cleanup if a repo looks compromised, and never runs anything it finds."
               image="/screenshot-feature-trust.png"
               imageAlt="The Repo Trust tab listing a repository's auto-run hooks with a plain-language explanation of what each one runs"
               href="/docs/repo-trust"


### PR DESCRIPTION
Homepage + public README for FinderGit 0.12.0 — leading with Repo Trust catching the **Shai-Hulud / Miasma** supply-chain dropper across every branch (not just your checkout), so it's visible and findable.

- **Homepage (`Welcome.tsx`)** — the feature card and the showcase row now name the worm and the dropper / all-branches detection (`Catch a supply-chain worm before it runs`).
- **Public README** — new *Repo Trust — supply-chain safety* entry (worm-named) + *Repo Maintenance* + a Git LFS requirement note.

The `content/repo-trust.mdx` docs page (worm-named intro + dropper / all-refs / dev-container / remediation sections) is **not** in this PR — it rides `release.sh` so the docs land in lockstep with the binary.

Merge before running `release.sh 0.12.0`. Worth a `yarn dev` visual pass on the homepage first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Repo Trust feature documentation to highlight supply-chain safety capabilities, including dropper payload detection and auto-run hooks monitoring
  * Added Repo Maintenance feature documentation describing disk usage breakdown and cleanup actions
  * Expanded system requirements documentation with Git LFS prerequisites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->