### PR TITLE
feat: add "Buy me a coffee" button next to Become a sponsor

### DIFF
--- a/components/MantineFooter/MantineFooter.tsx
+++ b/components/MantineFooter/MantineFooter.tsx
@@ -5,6 +5,7 @@ import {
   IconBrandMantine,
   IconBrandVercel,
   IconBrandX,
+  IconCoffee,
   IconHeartFilled,
   IconMailHeart,
   IconPlus,
@@ -179,19 +180,33 @@ export const MantineFooter = () => {
               </Stack>
             </Anchor>
           </Group>
-          <Button
-            mb="xl"
-            component="a"
-            href="https://github.com/sponsors/gfazioli"
-            target="_blank"
-            rel="noopener noreferrer"
-            variant="gradient"
-            gradient={{ from: 'pink', to: 'grape' }}
-            leftSection={<IconHeartFilled size={16} />}
-            radius="xl"
-          >
-            Become a sponsor
-          </Button>
+          <Group mb="xl" gap="sm" justify="center">
+            <Button
+              component="a"
+              href="https://github.com/sponsors/gfazioli"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="gradient"
+              gradient={{ from: 'pink', to: 'grape' }}
+              leftSection={<IconHeartFilled size={16} />}
+              radius="xl"
+            >
+              Become a sponsor
+            </Button>
+            <Button
+              component="a"
+              href="https://donate.stripe.com/fZu4gy4Tn3b1dgudGx0co00"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="filled"
+              color="yellow"
+              autoContrast
+              leftSection={<IconCoffee size={16} />}
+              radius="xl"
+            >
+              Buy me a coffee
+            </Button>
+          </Group>
         </Stack>
 
         <Divider my={16} className={classes.lastDivider} />


### PR DESCRIPTION
Adds a one-time-donation **Buy me a coffee** button (Stripe) in the footer, right next to the recurring **Become a sponsor** CTA — yellow filled (`autoContrast` for readable text), coffee icon. Mirrors the in-app About & Support addition shipping in 0.12.0.

Component change, so it deploys via Vercel on merge (independent of the app release). Worth a quick `yarn dev` look before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The footer now includes a "Buy me a coffee" donation button, providing supporters with an additional way to contribute alongside the existing sponsor option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->