### PR TITLE
fix: white text on the Buy me a coffee button

### DIFF
--- a/components/MantineFooter/MantineFooter.tsx
+++ b/components/MantineFooter/MantineFooter.tsx
@@ -200,9 +200,12 @@ export const MantineFooter = () => {
               rel="noopener noreferrer"
               variant="filled"
               color="yellow"
-              autoContrast
               leftSection={<IconCoffee size={16} />}
               radius="xl"
+              styles={{
+                label: { color: 'var(--mantine-color-white)' },
+                section: { color: 'var(--mantine-color-white)' },
+              }}
             >
               Buy me a coffee
             </Button>


### PR DESCRIPTION
Switch the footer Buy-me-a-coffee button's label + icon to white (was dark via `autoContrast` on the yellow fill).