### PR TITLE
feat(seo): sitemap, structured data, per-page descriptions & manifest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ In `app/layout.tsx`, CSS imports must follow this order:
 - The app is described as: "A Git-aware file browser for macOS"
 - Key selling points: sortable columns, live git status, inline diff viewer, git actions, search & filter, native macOS app
 - Target audience: developers who use Git and want a better file browsing experience on macOS
-- Download links point to GitHub Releases: `https://github.com/gfazioli/FinderGit/releases/latest`
+- Download links point to GitHub Releases on the **website** repo (the FinderGit app repo is private, so releases are published here): `https://github.com/gfazioli/findergit-website/releases/latest` — matches `config.app.downloadUrl`.
 
 ### No infrastructure leaks in user-facing copy
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,7 @@ import { ColorSchemeScript, mantineHtmlProps, MantineProvider } from '@mantine/c
 // !! End of important imports !!
 
 import { MantineFooter, MantineNavBar } from '@/components';
+import { WebsiteJsonLd } from '@/components/StructuredData/StructuredData';
 import config from '@/config';
 import { theme } from '../theme';
 
@@ -36,10 +37,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-        <meta
-          name="viewport"
-          content="minimum-scale=1, initial-scale=1, width=device-width, user-scalable=no"
-        />
+        {/*
+          No manual viewport meta: Next emits `width=device-width,
+          initial-scale=1` by default. The previous override added
+          `user-scalable=no`, which blocks pinch-zoom — an accessibility
+          regression (and a Lighthouse flag). Let the default stand so
+          users can zoom.
+        */}
       </Head>
       <body>
         <MantineProvider theme={theme} defaultColorScheme={head.mantine.defaultColorScheme}>
@@ -68,6 +72,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             {children}
           </Layout>
         </MantineProvider>
+        <WebsiteJsonLd />
         <Analytics />
       </body>
     </html>

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -16,15 +16,13 @@ export default function manifest(): MetadataRoute.Manifest {
     display: 'standalone',
     theme_color: '#228be6',
     background_color: '#111111',
+    // `any` only: the android-chrome icons have no maskable safe-zone
+    // padding, so declaring them `maskable` would crop the corners on
+    // shaped Android launchers. A dedicated padded asset can add maskable
+    // later if Android PWA install ever matters (this is a macOS app site).
     icons: [
       { src: '/android-chrome-192x192.png', sizes: '192x192', type: 'image/png', purpose: 'any' },
       { src: '/android-chrome-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'any' },
-      {
-        src: '/android-chrome-512x512.png',
-        sizes: '512x512',
-        type: 'image/png',
-        purpose: 'maskable',
-      },
     ],
   };
 }

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+import config from '@/config';
+
+/**
+ * Web app manifest. Adds the mobile/PWA install signal that was missing and
+ * puts the previously-orphaned `android-chrome-*` icons to use. `theme_color`
+ * matches the app's brand blue; `background_color` matches the site's default
+ * dark scheme.
+ */
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'FinderGit — Native macOS File Browser with Git Intelligence',
+    short_name: 'FinderGit',
+    description: config.metadata.description,
+    start_url: '/',
+    display: 'standalone',
+    theme_color: '#228be6',
+    background_color: '#111111',
+    icons: [
+      { src: '/android-chrome-192x192.png', sizes: '192x192', type: 'image/png', purpose: 'any' },
+      { src: '/android-chrome-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'any' },
+      { src: '/android-chrome-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
+    ],
+  };
+}

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -19,7 +19,12 @@ export default function manifest(): MetadataRoute.Manifest {
     icons: [
       { src: '/android-chrome-192x192.png', sizes: '192x192', type: 'image/png', purpose: 'any' },
       { src: '/android-chrome-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'any' },
-      { src: '/android-chrome-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
+      {
+        src: '/android-chrome-512x512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
     ],
   };
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,11 @@
+import { SoftwareApplicationJsonLd } from '@/components/StructuredData/StructuredData';
 import { Welcome } from '@/components/Welcome/Welcome';
 
 export default function HomePage() {
-  return <Welcome />;
+  return (
+    <>
+      <SoftwareApplicationJsonLd />
+      <Welcome />
+    </>
+  );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -30,8 +30,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
       return { url, lastModified, changeFrequency: 'weekly', priority };
     });
 
-  return [
-    { url: `${base}/`, lastModified: new Date(), changeFrequency: 'weekly', priority: 1 },
-    ...docs,
-  ];
+  // No `lastModified` on the homepage: there's no single content file to
+  // stat, and a build-time `new Date()` would report it as changed on every
+  // deploy, nudging needless recrawls. Omitting it is the honest signal.
+  return [{ url: `${base}/`, changeFrequency: 'weekly', priority: 1 }, ...docs];
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from 'next';
+import { readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import config from '@/config';
+
+/**
+ * Build-time sitemap. Enumerates the MDX pages under `content/` (served by
+ * Nextra at `/docs/...`) plus the homepage, so crawlers get the full URL set
+ * — there was no sitemap before, which left discovery entirely to internal
+ * linking. `lastModified` comes from each file's mtime so re-crawls are
+ * scoped to pages that actually changed.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = config.metadata.metadataBase.toString().replace(/\/$/, '');
+  const contentDir = path.join(process.cwd(), 'content');
+
+  const docs: MetadataRoute.Sitemap = readdirSync(contentDir)
+    .filter((file) => file.endsWith('.mdx'))
+    .map((file) => {
+      const slug = file.replace(/\.mdx$/, '');
+      const url = slug === 'index' ? `${base}/docs` : `${base}/docs/${slug}`;
+      let lastModified = new Date();
+      try {
+        lastModified = statSync(path.join(contentDir, file)).mtime;
+      } catch {
+        // Fall back to build time if the stat fails.
+      }
+      // The docs landing and the release notes are the liveliest pages.
+      const priority = slug === 'index' || slug === 'release-notes' ? 0.9 : 0.8;
+      return { url, lastModified, changeFrequency: 'weekly', priority };
+    });
+
+  return [
+    { url: `${base}/`, lastModified: new Date(), changeFrequency: 'weekly', priority: 1 },
+    ...docs,
+  ];
+}

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -1,0 +1,170 @@
+import config from '@/config';
+
+/**
+ * JSON-LD structured data (schema.org). Rendered server-side so the markup
+ * is in the initial HTML where crawlers read it. Three schemas:
+ *
+ * - `WebsiteJsonLd` (site-wide, in the root layout): the WebSite + publisher
+ *   Organization entity, for the knowledge graph and brand recognition.
+ * - `SoftwareApplicationJsonLd` (homepage): the app itself — free, macOS,
+ *   developer tool — eligible for an application rich result.
+ * - `FaqJsonLd` (FAQ page): the Q&A, eligible for FAQ rich snippets.
+ *
+ * No `aggregateRating` is emitted — there are no real ratings to cite, and
+ * fabricating one violates Google's guidelines.
+ */
+
+const SITE = config.metadata.metadataBase.toString().replace(/\/$/, '');
+
+function JsonLd({ data }: { data: object }) {
+  return (
+    <script
+      type="application/ld+json"
+      // Structured data is static, author-controlled JSON — no user input is
+      // interpolated, so serializing it directly is safe.
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}
+
+export function WebsiteJsonLd() {
+  return (
+    <JsonLd
+      data={{
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'WebSite',
+            '@id': `${SITE}/#website`,
+            url: `${SITE}/`,
+            name: 'FinderGit',
+            description: config.metadata.description,
+            publisher: { '@id': `${SITE}/#organization` },
+            inLanguage: 'en',
+          },
+          {
+            '@type': 'Organization',
+            '@id': `${SITE}/#organization`,
+            name: 'FinderGit',
+            url: `${SITE}/`,
+            logo: { '@type': 'ImageObject', url: `${SITE}/icon-512x512.png` },
+          },
+        ],
+      }}
+    />
+  );
+}
+
+export function SoftwareApplicationJsonLd() {
+  return (
+    <JsonLd
+      data={{
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareApplication',
+        name: 'FinderGit',
+        description: config.metadata.description,
+        applicationCategory: 'DeveloperApplication',
+        operatingSystem: `macOS ${config.app.minMacOS}+`,
+        url: `${SITE}/`,
+        downloadUrl: config.app.downloadUrl,
+        softwareVersion: config.app.version,
+        image: `${SITE}/opengraph-image.jpeg`,
+        screenshot: `${SITE}/screenshot-hero-overview.png`,
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        publisher: { '@id': `${SITE}/#organization` },
+      }}
+    />
+  );
+}
+
+// Plain-text mirror of the visible answers in `components/FAQ/FAQ.tsx`.
+// Google requires the schema text to match what's on the page — keep these
+// in sync with FAQ.tsx whenever an answer changes.
+const FAQ_ENTRIES: { question: string; answer: string }[] = [
+  {
+    question: 'What is FinderGit?',
+    answer:
+      'FinderGit is a native macOS application that works as a Git-aware file browser. Think of it as Finder’s list view, but with Git status, branch info, inline diffs, and commit/push/pull actions built in.',
+  },
+  {
+    question: 'Is FinderGit free?',
+    answer:
+      'Yes, FinderGit is currently free. If you find it useful, consider sponsoring the project.',
+  },
+  {
+    question: 'Is FinderGit on the App Store? How do updates work?',
+    answer:
+      'FinderGit is distributed directly from findergit.app as a signed and notarized DMG — it’s not on the App Store. Updates are automatic: the app checks for new releases and installs them in place, so you’re always one click away from the latest version.',
+  },
+  {
+    question: 'What macOS version do I need?',
+    answer:
+      'macOS 15 (Sequoia) or later. FinderGit is built with SwiftUI and uses APIs available from macOS 15+.',
+  },
+  {
+    question: 'Does FinderGit replace my Git client?',
+    answer:
+      'Not entirely — but it covers more ground every release. Day-to-day work happens without leaving the app: status across many repos at once, stage/unstage and discard, commit (with AI-generated messages), push/pull/fetch, branch switching, and keeping forks in sync with their upstream. For advanced surgery (interactive rebase, cherry-pick, complex merges) you’ll still want a full Git client or the terminal.',
+  },
+  {
+    question: 'Do I need to connect a GitHub account?',
+    answer:
+      'Only for the GitHub-powered extras — the Account dashboard, the issue / pull-request / star counts in the file browser, and new-star alerts. FinderGit reuses the GitHub CLI if it’s already set up, or a personal access token you paste into Settings — kept in your Keychain, never written to disk. Plain browsing, Git status, diffs and commit / push / pull all work with no GitHub connection at all.',
+  },
+  {
+    question: 'Can FinderGit tell me when one of my repos gets a star?',
+    answer:
+      'Yes. The Account view shows a badge the moment a repository earns a star — naming which repo, not just bumping a number — and you can optionally turn on desktop notifications in Settings → Git. It checks periodically in the background while the app is running.',
+  },
+  {
+    question: 'How does FinderGit detect repositories?',
+    answer:
+      'When you add a root folder, FinderGit recursively scans for directories containing .git/. The scan depth is configurable in Settings (default: 5 levels). Heavy directories like node_modules and DerivedData are automatically skipped.',
+  },
+  {
+    question: 'Does FinderGit modify my repositories?',
+    answer:
+      'Only when you explicitly perform an action (commit, push, pull, stage, etc.). FinderGit reads your repository state via git status and git diff — it never modifies anything without your command.',
+  },
+  {
+    question: 'Is it safe to open repositories I don’t fully trust?',
+    answer:
+      'That’s what Repo Trust is for. FinderGit scans each repository’s auto-run surface — hooks and configuration that could execute code when you open, build, or install — without ever running any of it. Repos with findings are flagged in the list, and you get an alert when that surface changes after a pull.',
+  },
+  {
+    question: 'Does FinderGit send my data anywhere?',
+    answer:
+      'No telemetry, ever. GitHub data (issues, pull requests, stars, fork status) is fetched directly from api.github.com using your own credentials. The only exception is the optional AI commit message feature: when you click ✨ AI, your staged diff is sent to generate the message — nothing is stored, and nothing is sent unless you ask.',
+  },
+  {
+    question: 'How does the live update work?',
+    answer:
+      'FinderGit uses macOS FSEvents to monitor file system changes in real time. When a file changes inside a watched repository, the status is automatically refreshed within ~300ms.',
+  },
+  {
+    question: 'I found a bug. How do I report it?',
+    answer:
+      'Please open a Bug Report on GitHub. Include your FinderGit version, macOS version, and steps to reproduce the issue. Screenshots are very helpful!',
+  },
+  {
+    question: 'I have an idea for a new feature. Where can I suggest it?',
+    answer:
+      'We’d love to hear your ideas! Open a Feature Request on GitHub and describe what you’d like FinderGit to do. The more detail you provide, the better we can evaluate and prioritize it.',
+  },
+];
+
+export function FaqJsonLd() {
+  return (
+    <JsonLd
+      data={{
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: FAQ_ENTRIES.map((entry) => ({
+          '@type': 'Question',
+          name: entry.question,
+          acceptedAnswer: { '@type': 'Answer', text: entry.answer },
+        })),
+      }}
+    />
+  );
+}

--- a/content/account.mdx
+++ b/content/account.mdx
@@ -1,3 +1,7 @@
+---
+description: "The Account dashboard brings your GitHub profile into FinderGit: followers, stars, public and private repo counts, a year of contributions, and your top repos, languages and orgs."
+---
+
 # Account
 
 The **Account** view turns FinderGit into a window onto your GitHub profile — avatar, bio, the numbers that matter, and a full year of contributions — without leaving the app or opening a browser.

--- a/content/ai-commit-messages.mdx
+++ b/content/ai-commit-messages.mdx
@@ -1,3 +1,7 @@
+---
+description: "Generate a properly formatted commit message from your staged diff with one click in FinderGit — free, no API key, with tone, length and Conventional Commits options."
+---
+
 # AI Commit Messages
 
 Generate properly-formatted Git commit messages from your staged diff with one click. Available since **FinderGit 0.5.0**.

--- a/content/detail-panel.mdx
+++ b/content/detail-panel.mdx
@@ -1,3 +1,7 @@
+---
+description: "The FinderGit detail panel: a five-tab view — Overview, Unstage, Commits, Issues, Pull Requests — with docked Fetch, Pull and Push actions for the selected repository."
+---
+
 import { Kbd } from '@/components/Kbd';
 
 # Detail Panel

--- a/content/detail-panel.mdx
+++ b/content/detail-panel.mdx
@@ -1,5 +1,5 @@
 ---
-description: "The FinderGit detail panel: a five-tab view — Overview, Unstage, Commits, Issues, Pull Requests — with docked Fetch, Pull and Push actions for the selected repository."
+description: "The FinderGit detail panel for the selected repository: tabbed views for Overview, staging and discard, commits, branches, and GitHub issues and pull requests, with docked Fetch, Pull and Push actions."
 ---
 
 import { Kbd } from '@/components/Kbd';

--- a/content/diff-viewer.mdx
+++ b/content/diff-viewer.mdx
@@ -1,3 +1,7 @@
+---
+description: "Review changes in FinderGit's inline diff viewer: colored, line-numbered diffs for any modified file, themed for light and dark mode."
+---
+
 # Diff Viewer
 
 FinderGit includes an inline diff viewer that shows changes for any modified file.

--- a/content/faq.mdx
+++ b/content/faq.mdx
@@ -1,7 +1,14 @@
+---
+description: "Answers to common questions about FinderGit — the free, native macOS Git-aware file browser: pricing, macOS requirements, GitHub setup, privacy, and how it compares to a full Git client."
+---
+
 # FAQ
 
 <div style={{ marginTop: 32 }} />
 
 import { FAQ } from "@/components/FAQ/FAQ";
+import { FaqJsonLd } from "@/components/StructuredData/StructuredData";
+
+<FaqJsonLd />
 
 <FAQ />

--- a/content/file-browser.mdx
+++ b/content/file-browser.mdx
@@ -1,3 +1,7 @@
+---
+description: "Browse files in a Finder-style outline with live Git status badges, sortable columns, fork awareness, GitHub Issue/PR/Star columns, in-window Quick Look, and a fast file filter."
+---
+
 # File Browser
 
 The file browser is the heart of FinderGit. It presents your files in an expandable outline table, similar to Finder's list view, but enriched with Git information.

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -1,3 +1,7 @@
+---
+description: "Install FinderGit and add your first root folder. How it scans for Git repositories on macOS, the three-pane interface, and first-launch notarization notes."
+---
+
 # Getting Started
 
 ## Installation

--- a/content/git-actions.mdx
+++ b/content/git-actions.mdx
@@ -1,3 +1,7 @@
+---
+description: "Stage, commit, push, pull, fetch, switch branches and discard changes from FinderGit — via the docked action bar, the Unstage tab and context menus, each with a keyboard shortcut."
+---
+
 # Git Actions
 
 FinderGit lets you perform common Git operations directly from the app, without opening a terminal.

--- a/content/github-integration.mdx
+++ b/content/github-integration.mdx
@@ -1,3 +1,7 @@
+---
+description: "Connect FinderGit to GitHub with the GitHub CLI or a personal access token to enable the Issues, Pull Requests and Stars columns, the Account dashboard, and fork awareness."
+---
+
 import { Kbd } from '@/components/Kbd';
 
 # GitHub Integration

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -1,3 +1,7 @@
+---
+description: "FinderGit documentation — get started with the native macOS Git-aware file browser: install it, browse repositories with live Git status, inline diffs, and one-click Git actions."
+---
+
 # FinderGit
 
 **FinderGit** is a native macOS application that combines file browsing with Git intelligence. Instead of switching between Finder and a Git client, you get everything in one window.

--- a/content/keyboard-shortcuts.mdx
+++ b/content/keyboard-shortcuts.mdx
@@ -1,3 +1,7 @@
+---
+description: "Every FinderGit keyboard shortcut — file operations, navigation, view, repository Git actions and settings — for fast, mouse-free work on macOS."
+---
+
 # Keyboard Shortcuts
 
 FinderGit supports many keyboard shortcuts for fast navigation and Git operations.

--- a/content/overview.mdx
+++ b/content/overview.mdx
@@ -1,3 +1,7 @@
+---
+description: "The Overview dashboard aggregates every repository under all your root folders — clean, modified and unpushed counts, disk usage, stars, and a needs-attention list."
+---
+
 # Overview
 
 The **Overview** is FinderGit's default landing view: a single dashboard that aggregates **every repository under all your root folders** — so the moment you open the app you know what needs attention, without clicking into a single repo.

--- a/content/release-notes.mdx
+++ b/content/release-notes.mdx
@@ -8,6 +8,8 @@ import config from '@/config';
 <ReleaseNotes />
 
 export const metadata = {
+    description:
+        "What's new in FinderGit — release notes for the native macOS Git-aware file browser, with the features, fixes and improvements in each version.",
     toc: await (async () => {
         try {
             // Pass `GITHUB_TOKEN` whenever it's available. Without it

--- a/content/repo-maintenance.mdx
+++ b/content/repo-maintenance.mdx
@@ -1,3 +1,7 @@
+---
+description: "Reclaim disk space in FinderGit: see where each repository's Git data goes, then free it with a one-click Optimize or a careful, configurable Deep Clean."
+---
+
 # Repo Maintenance
 
 Over time a Git repository accumulates loose objects, redundant pack files, and stale reflog entries — disk space that no longer earns its keep. FinderGit surfaces all of it in a dedicated **Maintenance** tab and lets you reclaim it without opening a terminal or remembering the right incantation.

--- a/content/repo-trust.mdx
+++ b/content/repo-trust.mdx
@@ -1,3 +1,7 @@
+---
+description: "Repo Trust scans each repository's auto-run surface — the hooks and config that can execute code when you open, build or install it — without ever running any of it."
+---
+
 # Repo Trust
 
 Cloning or pulling a repository can quietly arm it to run code on your machine — the moment you open the folder in your editor, the first time an AI coding agent loads it, or as soon as you run `npm install`. That's exactly how recent supply-chain worms — **Shai-Hulud** and its **Miasma** variant — have spread: a hijacked maintainer account commits an innocuous-looking hook, plus an obfuscated dropper payload, that executes automatically before you've reviewed a single line.

--- a/content/settings.mdx
+++ b/content/settings.mdx
@@ -1,3 +1,7 @@
+---
+description: "Configure FinderGit: startup and updates, file-browser scan depth, the Git binary path and fetch behavior, AI commit messages, star notifications, terminal and advanced options."
+---
+
 # Settings
 
 Open Settings with <Kbd>⌘</Kbd> <Kbd>,</Kbd> or from the menu **FinderGit → Settings**.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,8 @@
 # https://findergit.app/robots.txt
-#
-# Search engines are welcome.
+
+# ─────────────────────────────────────────────────────────────
+# Search engines — welcome.
+# ─────────────────────────────────────────────────────────────
 User-agent: Googlebot
 Allow: /
 
@@ -19,14 +21,49 @@ Allow: /
 User-agent: YandexBot
 Allow: /
 
-# Block AI training / scraping crawlers (high CDN cost, no SEO value)
-User-agent: GPTBot
-Disallow: /
+User-agent: Applebot
+Allow: /
+
+# ─────────────────────────────────────────────────────────────
+# AI answer engines & social link unfurlers — allowed.
+# Low crawl volume, high discovery value (AI search results +
+# rendered link previews on Facebook / Messenger / WhatsApp).
+# NOTE: these are ALSO gated by the Vercel firewall — relax the
+# matching rule there too, or the edge block overrides this file.
+# ─────────────────────────────────────────────────────────────
+User-agent: OAI-SearchBot
+Allow: /
 
 User-agent: ChatGPT-User
-Disallow: /
+Allow: /
 
-User-agent: OAI-SearchBot
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: DuckAssistBot
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
+User-agent: facebookexternalhit
+Allow: /
+
+User-agent: Facebot
+Allow: /
+
+User-agent: FacebookBot
+Allow: /
+
+# ─────────────────────────────────────────────────────────────
+# AI training / bulk scrapers — blocked.
+# Heavy, repeated whole-site crawls: high CDN + ISR-read cost,
+# no SEO value. These are what spiked ISR Reads before.
+# ─────────────────────────────────────────────────────────────
+User-agent: GPTBot
 Disallow: /
 
 User-agent: ClaudeBot
@@ -36,12 +73,6 @@ User-agent: Claude-Web
 Disallow: /
 
 User-agent: anthropic-ai
-Disallow: /
-
-User-agent: PerplexityBot
-Disallow: /
-
-User-agent: Perplexity-User
 Disallow: /
 
 User-agent: Google-Extended
@@ -65,22 +96,7 @@ Disallow: /
 User-agent: Meta-ExternalFetcher
 Disallow: /
 
-User-agent: FacebookBot
-Disallow: /
-
-User-agent: facebookexternalhit
-Disallow: /
-
-User-agent: Facebot
-Disallow: /
-
 User-agent: ImagesiftBot
-Disallow: /
-
-User-agent: DuckAssistBot
-Disallow: /
-
-User-agent: YouBot
 Disallow: /
 
 User-agent: cohere-ai
@@ -98,6 +114,10 @@ Disallow: /
 User-agent: omgilibot
 Disallow: /
 
-# Default rule for everything else
+# ─────────────────────────────────────────────────────────────
+# Everything else — allowed.
+# ─────────────────────────────────────────────────────────────
 User-agent: *
 Allow: /
+
+Sitemap: https://findergit.app/sitemap.xml


### PR DESCRIPTION
A focused SEO pass to improve discoverability. The baseline was already decent (strong root metadata, per-page titles + canonicals, complete OG/Twitter cards); this fills the structural gaps.

## What's added
- **Sitemap** (`app/sitemap.ts`) — homepage + all 16 docs pages, `lastModified` from file mtime. There was none before. Referenced from `robots.txt` via a `Sitemap:` directive.
- **Structured data (JSON-LD)** — none existed:
  - `SoftwareApplication` on the homepage (free, macOS, developer tool) → eligible for an app rich result.
  - `WebSite` + publisher `Organization` site-wide.
  - `FAQPage` on `/docs/faq` → eligible for FAQ rich snippets (text mirrors the visible answers, per Google's guideline).
- **Unique meta description per docs page** — all 16 pages previously emitted the same generic site description (duplicate descriptions). Each now has a unique, keyword-aware one via MDX frontmatter (`release-notes` via its existing `metadata` export, to avoid the frontmatter+metadata conflict).
- **Web manifest** (`app/manifest.ts`) — adds the PWA/mobile signal and puts the previously-orphaned `android-chrome-*` icons to use.
- **Viewport a11y fix** — removed the manual `user-scalable=no` viewport (blocked pinch-zoom, a Lighthouse flag); Next's zoom-friendly default now applies.

## robots.txt — cost-aware AI policy
Opened to **low-volume, high-value** crawlers (AI answer engines: OAI-SearchBot, ChatGPT-User, PerplexityBot, Perplexity-User, DuckAssistBot, YouBot; social unfurlers: facebookexternalhit, Facebot, FacebookBot) while keeping the **heavy training/bulk scrapers blocked** (GPTBot, ClaudeBot, CCBot, Bytespider, Amazonbot, Meta-*, Google-Extended, Applebot-Extended, …) — those were the ones that spiked ISR Reads.

> ⚠️ These bots are **also gated by the Vercel firewall**. The robots.txt change alone won't let them in — the matching Vercel rule must be relaxed too. And more visibility = more human traffic = more ISR Reads (currently ~746K/1M); pages are static/CDN-cached so repeat hits are cheap, but worth monitoring.

## Verified
Production build green; `/sitemap.xml` (17 URLs), `/manifest.webmanifest`, homepage JSON-LD, per-page descriptions, and FAQ `FAQPage` all confirmed on the dev server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Progressive Web App manifest with installation support and icon configuration
  * Added structured data (JSON-LD) across key pages (including FAQ) for richer search/snippet previews
  * Added automatic sitemap generation for documentation indexing
* **Bug Fixes**
  * Restored pinch-zoom behavior by removing the restrictive viewport setting
* **Documentation**
  * Added SEO-friendly page descriptions to documentation and release notes
  * Updated crawler directives to allow AI answer engines and social unfurlers
  * Updated download-link guidance in contributor instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->