### PR TITLE
feat: newsletter (footer CTA + scroll popup) + remove Launchpadly badge

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,7 @@ import { ColorSchemeScript, mantineHtmlProps, MantineProvider } from '@mantine/c
 // !! End of important imports !!
 
 import { MantineFooter, MantineNavBar } from '@/components';
+import { NewsletterModal } from '@/components/NewsletterSignup/NewsletterModal';
 import { WebsiteJsonLd } from '@/components/StructuredData/StructuredData';
 import config from '@/config';
 import { theme } from '../theme';
@@ -71,6 +72,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           >
             {children}
           </Layout>
+          <NewsletterModal />
         </MantineProvider>
         <WebsiteJsonLd />
         <Analytics />

--- a/components/MantineFooter/MantineFooter.tsx
+++ b/components/MantineFooter/MantineFooter.tsx
@@ -93,7 +93,7 @@ export const MantineFooter = () => {
                 <ActionIcon
                   variant="subtle"
                   component="a"
-                  href="https://www.undolog.com/s/findergit"
+                  href="https://findergit.substack.com"
                 >
                   <IconMailHeart size={24} />
                 </ActionIcon>

--- a/components/MantineFooter/MantineFooter.tsx
+++ b/components/MantineFooter/MantineFooter.tsx
@@ -24,6 +24,7 @@ import {
   Title,
 } from '@mantine/core';
 import { Logo } from '@/components/Logo/Logo';
+import { NewsletterSignup } from '@/components/NewsletterSignup/NewsletterSignup';
 import { AnimateBadge } from './AnimateBadge';
 import { ecosystem, highlights, resources, sponsors } from './links';
 import classes from './MantineFooter.module.css';
@@ -59,6 +60,8 @@ const VerticalLinks = ({ list }: { list: VerticalLink[] }) => {
 export const MantineFooter = () => {
   return (
     <div className={classes.contentFooter}>
+      <NewsletterSignup />
+      <Divider my="md" className={classes.lastDivider} />
       <Container className={classes.footer} size="lg">
         <Grid grow>
           <Grid.Col span={{ base: 12, sm: 4 }}>

--- a/components/NewsletterSignup/NewsletterCallToAction.tsx
+++ b/components/NewsletterSignup/NewsletterCallToAction.tsx
@@ -1,0 +1,33 @@
+import { IconMail } from '@tabler/icons-react';
+import { Button, Stack, Text, Title } from '@mantine/core';
+
+/**
+ * The shared newsletter call-to-action (heading + blurb + Subscribe button),
+ * used both in the footer band (NewsletterSignup) and the scroll-triggered
+ * popup (NewsletterModal) so the copy and link stay in one place.
+ *
+ * Links to the FinderGit Substack publication, which hosts the subscribe form.
+ */
+export function NewsletterCallToAction() {
+  return (
+    <Stack gap="xs" align="center">
+      <Title order={3} ta="center">
+        Get release updates
+      </Title>
+      <Text c="dimmed" ta="center" size="sm" maw={420}>
+        New version of FinderGit? Be the first to know — straight to your inbox.
+      </Text>
+      <Button
+        component="a"
+        href="https://findergit.substack.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        leftSection={<IconMail size={16} />}
+        radius="xl"
+        mt="xs"
+      >
+        Subscribe for updates
+      </Button>
+    </Stack>
+  );
+}

--- a/components/NewsletterSignup/NewsletterModal.tsx
+++ b/components/NewsletterSignup/NewsletterModal.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Modal } from '@mantine/core';
+import { useDisclosure, useLocalStorage, useWindowScroll } from '@mantine/hooks';
+import { NewsletterCallToAction } from './NewsletterCallToAction';
+
+/**
+ * Scroll-triggered newsletter prompt.
+ *
+ * Once the visitor has scrolled past the hero, a dismissible modal with the
+ * shared newsletter CTA appears — but only once: closing it persists a flag in
+ * localStorage so it never nags again on future visits. Mounted once globally
+ * in the root layout.
+ */
+const SCROLL_TRIGGER_PX = 1200;
+
+export function NewsletterModal() {
+  const [scroll] = useWindowScroll();
+  const [opened, { open, close }] = useDisclosure(false);
+  const [dismissed, setDismissed] = useLocalStorage({
+    key: 'findergit-newsletter-prompt-dismissed',
+    defaultValue: false,
+    // Read localStorage only after mount, so SSR and first client render agree.
+    getInitialValueInEffect: true,
+  });
+  // Auto-open at most once per page load (independent of the persisted flag).
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    if (!armed && !dismissed && scroll.y > SCROLL_TRIGGER_PX) {
+      setArmed(true);
+      open();
+    }
+  }, [scroll.y, dismissed, armed, open]);
+
+  const handleClose = () => {
+    setDismissed(true);
+    close();
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      centered
+      size="md"
+      radius="lg"
+      overlayProps={{ blur: 2 }}
+      transitionProps={{ transition: 'pop' }}
+      aria-label="Subscribe to the FinderGit newsletter"
+    >
+      <NewsletterCallToAction />
+    </Modal>
+  );
+}

--- a/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/components/NewsletterSignup/NewsletterSignup.tsx
@@ -1,51 +1,29 @@
 'use client';
 
-import Script from 'next/script';
-import { Container, Stack, Text, Title } from '@mantine/core';
+import { Container, Stack } from '@mantine/core';
 
 /**
  * Newsletter signup band.
  *
- * Embeds the hosted Sender form (account 07961bfe4b8790, form bmZpzG).
- * Sender's universal.js scans the DOM for `.sender-form-field` nodes and
- * renders the form into them — the form ships with built-in double opt-in and
- * bot protection, so no API token or custom subscribe endpoint lives on our
- * side. The loader is injected once via next/script (stable id ⇒ no dupes);
- * the footer is part of the root layout, so the target div is always mounted
- * by the time the afterInteractive script runs.
+ * Embeds the FinderGit Substack publication's subscribe form
+ * (findergit.substack.com). Substack hosts the form — double opt-in and bot
+ * protection are handled on their side, so no API token or custom subscribe
+ * endpoint lives on ours. The macOS app links to the same publication's
+ * /subscribe page, so web and app feed one list.
  */
 export function NewsletterSignup() {
   return (
     <Container size="sm" py="xl">
-      <Stack gap="md" align="center">
-        <Stack gap={4} align="center">
-          <Title order={3} ta="center">
-            Stay in the loop
-          </Title>
-          <Text c="dimmed" ta="center" size="sm">
-            Get an email when a new version of FinderGit ships. No spam, unsubscribe anytime.
-          </Text>
-        </Stack>
-        <div
-          className="sender-form-field"
-          data-sender-form-id="bmZpzG"
-          style={{ width: '100%', textAlign: 'left' }}
+      <Stack align="center">
+        <iframe
+          src="https://findergit.substack.com/embed?transparent=1&light=1"
+          title="Subscribe to FinderGit"
+          width={480}
+          height={320}
+          scrolling="no"
+          style={{ border: 0, background: 'transparent', maxWidth: '100%' }}
         />
       </Stack>
-      <Script id="sender-universal" strategy="afterInteractive">
-        {`(function (s, e, n, d, er) {
-  s['Sender'] = er;
-  s[er] = s[er] || function () { (s[er].q = s[er].q || []).push(arguments) };
-  s[er].l = 1 * new Date();
-  s[er].on = function (event, callback) {
-    s[er].listeners = s[er].listeners || {};
-    (s[er].listeners[event] = s[er].listeners[event] || []).push(callback);
-  };
-  var a = e.createElement(n), m = e.getElementsByTagName(n)[0];
-  a.async = 1; a.src = d; m.parentNode.insertBefore(a, m);
-})(window, document, 'script', 'https://cdn.sender.net/accounts_resources/universal.js', 'sender');
-sender('07961bfe4b8790');`}
-      </Script>
     </Container>
   );
 }

--- a/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/components/NewsletterSignup/NewsletterSignup.tsx
@@ -1,39 +1,16 @@
 'use client';
 
-import { IconMail } from '@tabler/icons-react';
-import { Button, Container, Stack, Text, Title } from '@mantine/core';
+import { Container } from '@mantine/core';
+import { NewsletterCallToAction } from './NewsletterCallToAction';
 
 /**
- * Newsletter signup CTA.
- *
- * Links to the FinderGit Substack publication (findergit.substack.com), which
- * hosts the subscribe form (double opt-in + bot protection on Substack's side).
- * A button rather than the raw Substack embed: the cross-origin embed renders
- * an opaque white card (its `transparent` param is ignored) that can't be
- * restyled to fit the dark footer. The macOS app links to the same publication.
+ * Newsletter signup band shown at the top of the footer (every page).
+ * Renders the shared CTA, which links to the FinderGit Substack publication.
  */
 export function NewsletterSignup() {
   return (
     <Container size="sm" py="xl">
-      <Stack gap="xs" align="center">
-        <Title order={3} ta="center">
-          Get release updates
-        </Title>
-        <Text c="dimmed" ta="center" size="sm" maw={420}>
-          New version of FinderGit? Be the first to know — straight to your inbox.
-        </Text>
-        <Button
-          component="a"
-          href="https://findergit.substack.com"
-          target="_blank"
-          rel="noopener noreferrer"
-          leftSection={<IconMail size={16} />}
-          radius="xl"
-          mt="xs"
-        >
-          Subscribe for updates
-        </Button>
-      </Stack>
+      <NewsletterCallToAction />
     </Container>
   );
 }

--- a/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/components/NewsletterSignup/NewsletterSignup.tsx
@@ -1,28 +1,38 @@
 'use client';
 
-import { Container, Stack } from '@mantine/core';
+import { IconMail } from '@tabler/icons-react';
+import { Button, Container, Stack, Text, Title } from '@mantine/core';
 
 /**
- * Newsletter signup band.
+ * Newsletter signup CTA.
  *
- * Embeds the FinderGit Substack publication's subscribe form
- * (findergit.substack.com). Substack hosts the form — double opt-in and bot
- * protection are handled on their side, so no API token or custom subscribe
- * endpoint lives on ours. The macOS app links to the same publication's
- * /subscribe page, so web and app feed one list.
+ * Links to the FinderGit Substack publication (findergit.substack.com), which
+ * hosts the subscribe form (double opt-in + bot protection on Substack's side).
+ * A button rather than the raw Substack embed: the cross-origin embed renders
+ * an opaque white card (its `transparent` param is ignored) that can't be
+ * restyled to fit the dark footer. The macOS app links to the same publication.
  */
 export function NewsletterSignup() {
   return (
     <Container size="sm" py="xl">
-      <Stack align="center">
-        <iframe
-          src="https://findergit.substack.com/embed?transparent=1&light=1"
-          title="Subscribe to FinderGit"
-          width={480}
-          height={320}
-          scrolling="no"
-          style={{ border: 0, background: 'transparent', maxWidth: '100%' }}
-        />
+      <Stack gap="xs" align="center">
+        <Title order={3} ta="center">
+          Get release updates
+        </Title>
+        <Text c="dimmed" ta="center" size="sm" maw={420}>
+          New version of FinderGit? Be the first to know — straight to your inbox.
+        </Text>
+        <Button
+          component="a"
+          href="https://findergit.substack.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          leftSection={<IconMail size={16} />}
+          radius="xl"
+          mt="xs"
+        >
+          Subscribe for updates
+        </Button>
       </Stack>
     </Container>
   );

--- a/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/components/NewsletterSignup/NewsletterSignup.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Script from 'next/script';
+import { Container, Stack, Text, Title } from '@mantine/core';
+
+/**
+ * Newsletter signup band.
+ *
+ * Embeds the hosted Sender form (account 07961bfe4b8790, form bmZpzG).
+ * Sender's universal.js scans the DOM for `.sender-form-field` nodes and
+ * renders the form into them — the form ships with built-in double opt-in and
+ * bot protection, so no API token or custom subscribe endpoint lives on our
+ * side. The loader is injected once via next/script (stable id ⇒ no dupes);
+ * the footer is part of the root layout, so the target div is always mounted
+ * by the time the afterInteractive script runs.
+ */
+export function NewsletterSignup() {
+  return (
+    <Container size="sm" py="xl">
+      <Stack gap="md" align="center">
+        <Stack gap={4} align="center">
+          <Title order={3} ta="center">
+            Stay in the loop
+          </Title>
+          <Text c="dimmed" ta="center" size="sm">
+            Get an email when a new version of FinderGit ships. No spam, unsubscribe anytime.
+          </Text>
+        </Stack>
+        <div
+          className="sender-form-field"
+          data-sender-form-id="bmZpzG"
+          style={{ width: '100%', textAlign: 'left' }}
+        />
+      </Stack>
+      <Script id="sender-universal" strategy="afterInteractive">
+        {`(function (s, e, n, d, er) {
+  s['Sender'] = er;
+  s[er] = s[er] || function () { (s[er].q = s[er].q || []).push(arguments) };
+  s[er].l = 1 * new Date();
+  s[er].on = function (event, callback) {
+    s[er].listeners = s[er].listeners || {};
+    (s[er].listeners[event] = s[er].listeners[event] || []).push(callback);
+  };
+  var a = e.createElement(n), m = e.getElementsByTagName(n)[0];
+  a.async = 1; a.src = d; m.parentNode.insertBefore(a, m);
+})(window, document, 'script', 'https://cdn.sender.net/accounts_resources/universal.js', 'sender');
+sender('07961bfe4b8790');`}
+      </Script>
+    </Container>
+  );
+}

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -588,21 +588,6 @@ export function Welcome() {
                   height={54}
                 />
               </a>
-              <a
-                href="https://launchpadly.co/startup/findergit"
-                target="_blank"
-                rel="noopener noreferrer"
-                data-launchpadly-badge="findergit"
-                data-launchpadly-badge-variant="listed-on"
-              >
-                <img
-                  src="https://launchpadly.co/embed/badges/startup/findergit.svg?variant=listed-on"
-                  alt="Launchpadly Startup Directory"
-                  width={260}
-                  height={48}
-                  style={{ display: 'block', border: 0 }}
-                />
-              </a>
             </Group>
           </Stack>
 


### PR DESCRIPTION
Newsletter signup + a small homepage tidy (one session).

## Newsletter — Substack (`findergit.substack.com`)
The publication hosts the subscribe form (double opt-in + bot protection on Substack's side) — no token or endpoint on ours. Two entry points share one CTA component:

- **`NewsletterCallToAction`** — shared heading + blurb + "Subscribe for updates" button (single source of truth).
- **Footer band** (`NewsletterSignup`) — on every page; also repoints the footer mail icon to the publication.
- **Scroll popup** (`NewsletterModal`) — auto-opens once after the visitor scrolls past the hero (`useWindowScroll` > 1200px), dismissible, and **never nags again** (closing persists a flag via `useLocalStorage`). Mounted once in the root layout.

> Uses a button/CTA rather than Substack's inline embed — the cross-origin embed renders an opaque white card (`transparent` ignored) that can't be restyled for the dark theme.

## Remove Launchpadly badge
`Welcome.tsx` — drop the Launchpadly hero badge; keep Product Hunt.

## Review
- `yarn typecheck` passes.
- `yarn dev`: footer CTA; scroll down past the hero to see the popup (clear `localStorage` key `findergit-newsletter-prompt-dismissed` or use a fresh window to re-trigger after dismissing); hero shows only the Product Hunt badge.