### PR TITLE
chore: point "Report an Issue" at the feedback email

### DIFF
--- a/app/_meta.tsx
+++ b/app/_meta.tsx
@@ -24,7 +24,7 @@ export default {
       },
       issues: {
         title: 'Report an Issue',
-        href: 'https://github.com/gfazioli/findergit-website/issues',
+        href: 'mailto:feedback@findergit.app?subject=FinderGit%20feedback',
       },
     },
   },

--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -130,14 +130,14 @@ const faqItems: { value: string; question: string; answer: ReactNode }[] = [
     question: 'I found a bug. How do I report it?',
     answer: (
       <>
-        Please open a{' '}
+        Please send us a{' '}
         <Anchor
-          href="https://github.com/gfazioli/findergit-website/issues/new?template=bug_report.yml"
+          href="mailto:feedback@findergit.app?subject=FinderGit%20bug%20report"
           size="sm"
         >
-          Bug Report
+          bug report
         </Anchor>{' '}
-        on GitHub. Include your FinderGit version, macOS version, and steps to reproduce the issue.
+        by email. Include your FinderGit version, macOS version, and steps to reproduce the issue.
         Screenshots are very helpful!
       </>
     ),
@@ -147,14 +147,14 @@ const faqItems: { value: string; question: string; answer: ReactNode }[] = [
     question: 'I have an idea for a new feature. Where can I suggest it?',
     answer: (
       <>
-        We&apos;d love to hear your ideas! Open a{' '}
+        We&apos;d love to hear your ideas! Send us a{' '}
         <Anchor
-          href="https://github.com/gfazioli/findergit-website/issues/new?template=feature_request.yml"
+          href="mailto:feedback@findergit.app?subject=FinderGit%20feature%20request"
           size="sm"
         >
-          Feature Request
+          feature request
         </Anchor>{' '}
-        on GitHub and describe what you&apos;d like FinderGit to do. The more detail you provide,
+        by email and describe what you&apos;d like FinderGit to do. The more detail you provide,
         the better we can evaluate and prioritize it.
       </>
     ),

--- a/components/MantineFooter/links/resources.ts
+++ b/components/MantineFooter/links/resources.ts
@@ -17,8 +17,7 @@ export const resources = [
   {
     key: 'issues',
     title: 'Report an Issue',
-    href: 'https://github.com/gfazioli/findergit-website/issues',
-    newWindow: true,
+    href: 'mailto:feedback@findergit.app?subject=FinderGit%20feedback',
   },
   {
     key: 'undolog',


### PR DESCRIPTION
## What

Repoint the website's two **"Report an Issue"** links — footer (`resources.ts`) and top-nav (`app/_meta.tsx`) — from the GitHub issues page to **`mailto:feedback@findergit.app`** (subject pre-filled).

## Why

Matches the macOS app (FinderGit PR #102) and the email-first feedback channel: anyone can report a bug or request a feature without a GitHub account. The `findergit.app` catch-all forwards it to the maintainer.

## Notes

- `yarn typecheck` passes.
- Dropped `newWindow` on the footer link (a `mailto:` opens the mail client, no new tab needed).
- **Open question:** the FAQ still links "I found a bug" / "I have an idea" to GitHub issue *templates* (`bug_report.yml` / `feature_request.yml`). Leaving those as-is for now — see PR discussion / can switch them to the same email if we want full consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated feedback reporting links across the application to use email submission with pre-filled details instead of the previous method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->