### PR TITLE
feat(nav): Community → Newsletter (Substack) instead of Blog

### DIFF
--- a/app/_meta.tsx
+++ b/app/_meta.tsx
@@ -18,9 +18,9 @@ export default {
     title: 'Community',
     type: 'menu',
     items: {
-      blog: {
-        title: 'Blog',
-        href: 'https://undolog.com/',
+      newsletter: {
+        title: 'Newsletter',
+        href: 'https://findergit.substack.com',
       },
       issues: {
         title: 'Report an Issue',


### PR DESCRIPTION
## What

In the top-nav **Community** menu, replace **Blog** (→ `undolog.com`) with **Newsletter** (→ `findergit.substack.com`).

## Why

The FinderGit newsletter lives on Substack and is FinderGit's own publication home — it deserves a spot in the primary navigation, alongside the existing footer subscribe CTA. The previous **Blog** item pointed at the Undolog company blog, which is more peripheral for a FinderGit visitor.

Nothing is lost: the **Undolog Blog** link stays in the footer *Resources* column, so the company blog is still one click away.

## Notes

- External link, so Nextra keeps the ↗ indicator (same as before).
- Internal menu key renamed `blog` → `newsletter`; it isn't referenced anywhere else.
- Verify on the Vercel preview: Community ▸ Newsletter ↗ → `https://findergit.substack.com`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the community menu to include a new **Newsletter** link.
  * Replaced the previous blog link with a direct Substack newsletter destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->