### PR TITLE
feat: surface the v0.18.0 localization on the homepage and FAQ

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -36,6 +36,12 @@ const faqItems: { value: string; question: string; answer: ReactNode }[] = [
       'macOS 15 (Sequoia) or later. FinderGit is built with SwiftUI and uses APIs available from macOS 15+.',
   },
   {
+    value: 'languages',
+    question: 'Which languages does FinderGit speak?',
+    answer:
+      'English, Italian, French, German, and Spanish. FinderGit follows your Mac’s system language automatically — there is no in-app switcher. To use a different language, reorder your preferred languages in System Settings → General → Language & Region.',
+  },
+  {
     value: 'replace',
     question: 'Does FinderGit replace my Git client?',
     answer:

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -104,7 +104,7 @@ const FAQ_ENTRIES: { question: string; answer: string }[] = [
   {
     question: 'Which languages does FinderGit speak?',
     answer:
-      'English, Italian, French, German, and Spanish. FinderGit follows your Mac’s system language automatically — there is no in-app switcher.',
+      'English, Italian, French, German, and Spanish. FinderGit follows your Mac’s system language automatically — there is no in-app switcher. To use a different language, reorder your preferred languages in System Settings → General → Language & Region.',
   },
   {
     question: 'Does FinderGit replace my Git client?',

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -102,6 +102,11 @@ const FAQ_ENTRIES: { question: string; answer: string }[] = [
       'macOS 15 (Sequoia) or later. FinderGit is built with SwiftUI and uses APIs available from macOS 15+.',
   },
   {
+    question: 'Which languages does FinderGit speak?',
+    answer:
+      'English, Italian, French, German, and Spanish. FinderGit follows your Mac’s system language automatically — there is no in-app switcher.',
+  },
+  {
     question: 'Does FinderGit replace my Git client?',
     answer:
       'Not entirely — but it covers more ground every release. Day-to-day work happens without leaving the app: status across many repos at once, stage/unstage and discard, commit (with AI-generated messages), push/pull/fetch, branch switching, and keeping forks in sync with their upstream. For advanced surgery (interactive rebase, cherry-pick, complex merges) you’ll still want a full Git client or the terminal.',

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -21,6 +21,7 @@ import {
   IconLayoutGrid,
   IconUserCircle,
   IconStar,
+  IconLanguage,
 } from '@tabler/icons-react';
 import {
   Box,
@@ -365,6 +366,15 @@ interface Feature {
 }
 
 const features: Feature[] = [
+  {
+    icon: IconLanguage,
+    title: 'Speaks Your Language',
+    description:
+      'Fully localized into English, Italian, French, German, and Spanish — FinderGit follows your Mac’s system language automatically.',
+    color: 'grape',
+    href: '/docs/getting-started#language',
+    badge: 'New',
+  },
   {
     icon: IconLayoutGrid,
     title: 'Overview Dashboard',


### PR DESCRIPTION
Adds the new-in-0.18.0 localization to the marketing surfaces that release.sh deliberately doesn't touch:

- **Welcome feature grid**: new "Speaks Your Language" tile (IconLanguage, grape, `New` badge) linking to the Getting Started → Language section that shipped with the release.
- **FAQ**: "Which languages does FinderGit speak?" — added to the accordion **and** to the JSON-LD `FAQ_ENTRIES` twin (separate copy, drifts silently otherwise).

Typecheck green. Preview with `yarn dev` before merging (homepage + /docs + FAQ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new FAQ entry explaining which languages FinderGit supports and how it follows the Mac’s system language settings.
  * Added a new “Speaks Your Language” feature card on the welcome screen with a link to the language setup guide.
  * Updated structured FAQ data so the new language question appears in generated search-friendly page metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->