### PR TITLE
feat(seo): attribute Twitter/X cards to @gfazioli

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -38,6 +38,8 @@ export default {
     },
     twitter: {
       card: 'summary_large_image',
+      site: '@gfazioli',
+      creator: '@gfazioli',
     },
     alternates: {
       canonical: './',


### PR DESCRIPTION
## What

Adds `twitter.site` and `twitter.creator` (`@gfazioli`) to the root metadata in `config/index.ts`, so shared FinderGit links render a "from @gfazioli" byline on X and the account accrues the card's engagement.

## Why

The site declared only `twitter: { card: 'summary_large_image' }` — cards carried no account attribution. `@gfazioli` is the handle already linked in the footer (`components/MantineFooter/MantineFooter.tsx`).

## Verification

- `tsc --noEmit` and `oxlint` both clean.
- Production Turbopack build + grep of the prerendered homepage HTML: previously **no** `twitter:site`/`twitter:creator` tags; after the change both emit `@gfazioli`.

Found via a focused SEO audit. The audit also considered a per-page canonical fix for `/docs/*` but **rejected it** — a build confirmed the docs pages already emit correct per-page canonicals (Next.js resolves the inherited relative `./` against the current route), so no change was warranted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated social sharing metadata so Twitter cards display the correct site and creator information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->