### PR TITLE
feat: add "Share this page" social buttons to footer

### DIFF
--- a/components/MantineFooter/MantineFooter.tsx
+++ b/components/MantineFooter/MantineFooter.tsx
@@ -95,10 +95,6 @@ export const MantineFooter = () => {
                   <IconMailHeart size={24} />
                 </ActionIcon>
               </Group>
-              <Text tt="uppercase" fz={11} fw={600} c="dimmed" mt={6}>
-                Share this page
-              </Text>
-              <ShareButtons />
             </Stack>
           </Grid.Col>
           <Grid.Col className={classes.column} span={2}>
@@ -214,6 +210,14 @@ export const MantineFooter = () => {
               Buy me a coffee
             </Button>
           </Group>
+        </Stack>
+
+        {/* Share this page */}
+        <Stack gap="xs" align="center" mt="md">
+          <Text tt="uppercase" fz={11} fw={600} c="dimmed">
+            Share this page
+          </Text>
+          <ShareButtons />
         </Stack>
 
         <Divider my={16} className={classes.lastDivider} />

--- a/components/MantineFooter/MantineFooter.tsx
+++ b/components/MantineFooter/MantineFooter.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mantine/core';
 import { Logo } from '@/components/Logo/Logo';
 import { NewsletterSignup } from '@/components/NewsletterSignup/NewsletterSignup';
+import { ShareButtons } from '@/components/ShareButtons/ShareButtons';
 import { AnimateBadge } from './AnimateBadge';
 import { apps, highlights, resources, sponsors } from './links';
 import classes from './MantineFooter.module.css';
@@ -94,6 +95,10 @@ export const MantineFooter = () => {
                   <IconMailHeart size={24} />
                 </ActionIcon>
               </Group>
+              <Text tt="uppercase" fz={11} fw={600} c="dimmed" mt={6}>
+                Share this page
+              </Text>
+              <ShareButtons />
             </Stack>
           </Grid.Col>
           <Grid.Col className={classes.column} span={2}>

--- a/components/ShareButtons/ShareButtons.tsx
+++ b/components/ShareButtons/ShareButtons.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import {
+  IconBrandBluesky,
+  IconBrandLinkedin,
+  IconBrandMastodon,
+  IconBrandReddit,
+  IconBrandX,
+  IconBrandYcombinator,
+  IconCheck,
+  IconLink,
+} from '@tabler/icons-react';
+import { ActionIcon, Group, Tooltip } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import config from '@/config';
+
+const ICON_SIZE = 18;
+
+// Mastodon is federated, so there is no single canonical share endpoint.
+// We route through a lightweight instance picker that lets the visitor pick
+// their own server. Swap this constant for a different picker or a hardcoded
+// instance if preferred.
+const MASTODON_SHARE = 'https://mastodonshare.com/';
+
+// e.g. "@gfazioli" -> "gfazioli" for the X `via` attribution param.
+const X_HANDLE = (config.metadata.twitter?.creator ?? '').replace(/^@/, '');
+
+type ShareTarget = {
+  key: string;
+  label: string;
+  Icon: typeof IconBrandX;
+  href: (url: string, title: string) => string;
+};
+
+const TARGETS: ShareTarget[] = [
+  {
+    key: 'x',
+    label: 'X',
+    Icon: IconBrandX,
+    href: (url, title) => {
+      const params = new URLSearchParams({ url, text: title });
+      if (X_HANDLE) {
+        params.set('via', X_HANDLE);
+      }
+      return `https://twitter.com/intent/tweet?${params}`;
+    },
+  },
+  {
+    key: 'bluesky',
+    label: 'Bluesky',
+    Icon: IconBrandBluesky,
+    // Bluesky has no separate url param — the link goes inside the post text.
+    href: (url, title) =>
+      `https://bsky.app/intent/compose?${new URLSearchParams({ text: `${title} ${url}` })}`,
+  },
+  {
+    key: 'mastodon',
+    label: 'Mastodon',
+    Icon: IconBrandMastodon,
+    href: (url, title) => `${MASTODON_SHARE}?${new URLSearchParams({ text: title, url })}`,
+  },
+  {
+    key: 'reddit',
+    label: 'Reddit',
+    Icon: IconBrandReddit,
+    href: (url, title) => `https://www.reddit.com/submit?${new URLSearchParams({ url, title })}`,
+  },
+  {
+    key: 'hackernews',
+    label: 'Hacker News',
+    Icon: IconBrandYcombinator,
+    href: (url, title) =>
+      `https://news.ycombinator.com/submitlink?${new URLSearchParams({ u: url, t: title })}`,
+  },
+  {
+    key: 'linkedin',
+    label: 'LinkedIn',
+    Icon: IconBrandLinkedin,
+    // LinkedIn no longer honours a custom title/summary — it reads the page's
+    // Open Graph tags, so only the URL is passed.
+    href: (url) =>
+      `https://www.linkedin.com/sharing/share-offsite/?${new URLSearchParams({ url })}`,
+  },
+];
+
+/**
+ * A row of "share this page" buttons. Resolves the current page's absolute URL
+ * from the pathname + the canonical site base, and uses the live document title
+ * as the share text. Icon-only, tooltip-labelled, theme-aware.
+ */
+export const ShareButtons = () => {
+  const pathname = usePathname();
+  const clipboard = useClipboard({ timeout: 1500 });
+
+  // Absolute URL of the current page, resolved against the canonical site base.
+  const url = new URL(pathname || '/', config.metadata.metadataBase).toString();
+
+  // Share text = the page <title>. Kept deterministic on first render (the
+  // configured default) so SSR and client hydration agree, then upgraded to the
+  // live document.title after mount — the value only ever feeds link query
+  // strings, so the post-mount swap is invisible.
+  const [title, setTitle] = useState<string>(config.metadata.title.default);
+  useEffect(() => {
+    if (typeof document !== 'undefined' && document.title) {
+      setTitle(document.title);
+    }
+  }, [pathname]);
+
+  return (
+    <Group gap="xs">
+      {TARGETS.map(({ key, label, Icon, href }) => (
+        <Tooltip key={key} label={label} withArrow>
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            component="a"
+            href={href(url, title)}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Share on ${label}`}
+          >
+            <Icon size={ICON_SIZE} />
+          </ActionIcon>
+        </Tooltip>
+      ))}
+      <Tooltip label={clipboard.copied ? 'Copied!' : 'Copy link'} withArrow>
+        <ActionIcon
+          variant="subtle"
+          color={clipboard.copied ? 'teal' : 'gray'}
+          onClick={() => clipboard.copy(url)}
+          aria-label="Copy link to this page"
+        >
+          {clipboard.copied ? <IconCheck size={ICON_SIZE} /> : <IconLink size={ICON_SIZE} />}
+        </ActionIcon>
+      </Tooltip>
+    </Group>
+  );
+};

--- a/components/ShareButtons/ShareButtons.tsx
+++ b/components/ShareButtons/ShareButtons.tsx
@@ -114,7 +114,6 @@ export const ShareButtons = () => {
         <Tooltip key={key} label={label} withArrow>
           <ActionIcon
             variant="subtle"
-            color="gray"
             component="a"
             href={href(url, title)}
             target="_blank"
@@ -128,7 +127,7 @@ export const ShareButtons = () => {
       <Tooltip label={clipboard.copied ? 'Copied!' : 'Copy link'} withArrow>
         <ActionIcon
           variant="subtle"
-          color={clipboard.copied ? 'teal' : 'gray'}
+          color={clipboard.copied ? 'teal' : undefined}
           onClick={() => clipboard.copy(url)}
           aria-label="Copy link to this page"
         >

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -43,6 +43,7 @@ import {
   Anchor,
 } from '@mantine/core';
 import config from '@/config';
+import { ShareButtons } from '@/components/ShareButtons/ShareButtons';
 import { FAQ } from '../FAQ/FAQ';
 import { ProblemSection } from '../ProblemSection/ProblemSection';
 import { SolutionSection } from '../SolutionSection/SolutionSection';
@@ -614,6 +615,9 @@ export function Welcome() {
                   height={54}
                 />
               </a>
+            </Group>
+            <Group justify="center" mt="sm">
+              <ShareButtons />
             </Group>
           </Stack>
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -4,3 +4,4 @@ export { Logo } from './Logo/Logo';
 export { MantineFooter } from './MantineFooter/MantineFooter';
 export { MantineNavBar } from './MantineNavBar/MantineNavBar';
 export { MantineNextraThemeObserver } from './MantineNextraThemeObserver/MantineNextraThemeObserver';
+export { ShareButtons } from './ShareButtons/ShareButtons';


### PR DESCRIPTION
## What

Adds a **"Share this page"** row to the site footer. The sites had "follow me" profile links but no way for a visitor to share the page they're on.

New `ShareButtons` client component with icon buttons for:

**X · Bluesky · Mastodon · Reddit · Hacker News · LinkedIn · Copy link**

It lives in the footer, so it shows on the homepage and every `/docs/*` page.

## How

- Absolute page URL resolved from `usePathname()` against `config.metadata.metadataBase`, so each page gets the correct canonical share link.
- Share text = live `document.title`, initialised to the configured default title on first render so SSR and hydration agree (no mismatch), then upgraded after mount. The URL is always correct per page regardless.
- Copy-to-clipboard via Mantine `useClipboard` (checkmark + "Copied!" tooltip).
- **No new dependency** — every brand icon ships with `@tabler/icons-react`.

## Notes for review

- **Mastodon** is federated, so there is no first-party share endpoint. It routes through the `mastodonshare.com` instance picker; the `MASTODON_SHARE` constant makes it a one-line swap if you'd prefer a different picker or want to drop it.
- Buttons use `variant="subtle" color="gray"` so they read as a secondary utility row, visually distinct from the brand-coloured follow icons above them.
- X uses the `via=gfazioli` attribution param (from `config.metadata.twitter.creator`).

## Verification

- `next build` green (compiles + static generation of all pages).
- `tsc --noEmit` and oxlint clean on the changed files.
- Confirmed in the built HTML: all 7 buttons render server-side with correct absolute per-page URLs (homepage → site root; `/docs/getting-started` → `…/docs/getting-started`).

Cross-ported identically to the sibling site (findergit-website / netfox-website). Pixel-level footer layout still worth a quick `yarn dev` look before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Share this page” section to the footer.
  * Added sharing options for X, Bluesky, Mastodon, Reddit, Hacker News, and LinkedIn.
  * Added a “Copy link” option with visual confirmation after copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->