### PR TITLE
fix(test): align the hero assertion with the current copy

### DIFF
--- a/components/Welcome/Welcome.test.tsx
+++ b/components/Welcome/Welcome.test.tsx
@@ -4,6 +4,8 @@ import { Welcome } from './Welcome';
 describe('Welcome component', () => {
   it('renders the hero title', () => {
     render(<Welcome />);
-    expect(screen.getByText(/your repositories were never meant to be/i)).toBeInTheDocument();
+    // Only the plain-text half of the headline is asserted: the rest ("Always live.") is rendered
+    // by TextAnimate, which splits it per character, so it is not a single text node.
+    expect(screen.getByText(/every git repo\. one window\./i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

`yarn test` has been red in this repo since commit `81d935b`, which replaced the hero copy without updating the assertion:

| | |
|---|---|
| asserted | `/your repositories were never meant to be/i` |
| actually rendered | "Every Git repo. One window. Always live." |

The old string existed nowhere in the codebase except this test file, so it could never pass again.

Surfaced during today's security sweep: the patching script stopped on it, and I deliberately left it out of that PR (#38) to keep it a visible, separate one-line fix rather than burying a code change inside a dependency patch.

## Note on what is asserted

Only the plain-text half of the headline. The rest ("Always live.") is rendered by `TextAnimate` with `by="character"`, which splits it into per-character nodes, so it is not matchable as a single text node.

## Test plan
- [x] yarn jest — 1/1
- [x] yarn test — typecheck + lint + jest all green