### PR TITLE
docs: explain how to verify a download, and what a scanner flag means

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -122,8 +122,11 @@ const faqItems: { value: string; question: string; answer: ReactNode }[] = [
           Verifying your download
         </Anchor>{' '}
         has the two commands. Antivirus engines do sometimes flag a notarized Mac app on a
-        machine-learning heuristic rather than an actual malware signature; if the checksum matches,
-        that is what you are looking at, and we report those to the vendor. If it does not match,{' '}
+        machine-learning heuristic rather than an actual malware signature. A matching checksum
+        can't prove a detection wrong on its own, but together with Apple's notarization scan and a
+        clean spctl run it makes a heuristic false positive much the likeliest reading, and we
+        report those to the vendor. If the checksum doesn't match, or macOS rejects the file, don't
+        open it —{' '}
         <Anchor
           href="mailto:feedback@findergit.app?subject=FinderGit%20download%20verification"
           size="sm"

--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -111,6 +111,30 @@ const faqItems: { value: string; question: string; answer: ReactNode }[] = [
     ),
   },
   {
+    value: 'verify',
+    question: 'How do I verify a download — and what if a virus scanner flags it?',
+    answer: (
+      <>
+        Every release is signed with an Apple Developer ID and notarized by Apple, and each release
+        page publishes the SHA-256 of its DMG, so you can confirm the file you downloaded is
+        byte-for-byte the one we shipped —{' '}
+        <Anchor href="/docs/getting-started#verifying-your-download" size="sm">
+          Verifying your download
+        </Anchor>{' '}
+        has the two commands. Antivirus engines do sometimes flag a notarized Mac app on a
+        machine-learning heuristic rather than an actual malware signature; if the checksum matches,
+        that is what you are looking at, and we report those to the vendor. If it does not match,{' '}
+        <Anchor
+          href="mailto:feedback@findergit.app?subject=FinderGit%20download%20verification"
+          size="sm"
+        >
+          tell us
+        </Anchor>
+        .
+      </>
+    ),
+  },
+  {
     value: 'privacy',
     question: 'Does FinderGit send my data anywhere?',
     answer: (

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -137,6 +137,11 @@ const FAQ_ENTRIES: { question: string; answer: string }[] = [
       'That’s what Repo Trust is for. FinderGit scans each repository’s auto-run surface — hooks and configuration that could execute code when you open, build, or install — without ever running any of it. Repos with findings are flagged in the list, and you get an alert when that surface changes after a pull.',
   },
   {
+    question: 'How do I verify a download — and what if a virus scanner flags it?',
+    answer:
+      'Every release is signed with an Apple Developer ID and notarized by Apple, and each release page publishes the SHA-256 of its DMG, so you can confirm the file you downloaded is byte-for-byte the one we shipped. Antivirus engines do sometimes flag a notarized Mac app on a machine-learning heuristic rather than an actual malware signature; if the checksum matches, that is what you are looking at, and we report those to the vendor. If it does not match, tell us.',
+  },
+  {
     question: 'Does FinderGit send my data anywhere?',
     answer:
       'No telemetry, ever. GitHub data (issues, pull requests, stars, fork status) is fetched directly from api.github.com using your own credentials. The only exception is the optional AI commit message feature: when you click ✨ AI, your staged diff is sent to generate the message — nothing is stored, and nothing is sent unless you ask.',

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -139,7 +139,7 @@ const FAQ_ENTRIES: { question: string; answer: string }[] = [
   {
     question: 'How do I verify a download — and what if a virus scanner flags it?',
     answer:
-      'Every release is signed with an Apple Developer ID and notarized by Apple, and each release page publishes the SHA-256 of its DMG, so you can confirm the file you downloaded is byte-for-byte the one we shipped. Antivirus engines do sometimes flag a notarized Mac app on a machine-learning heuristic rather than an actual malware signature; if the checksum matches, that is what you are looking at, and we report those to the vendor. If it does not match, tell us.',
+      'Every release is signed with an Apple Developer ID and notarized by Apple, and each release page publishes the SHA-256 of its DMG, so you can confirm the file you downloaded is byte-for-byte the one we shipped. Antivirus engines do sometimes flag a notarized Mac app on a machine-learning heuristic rather than an actual malware signature. A matching checksum can’t prove a detection wrong on its own, but together with Apple’s notarization scan and a clean spctl it makes a heuristic false positive much the likeliest reading, and we report those to the vendor. If the checksum doesn’t match, or macOS rejects the file, don’t open it — tell us.',
   },
   {
     question: 'Does FinderGit send my data anywhere?',

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -17,6 +17,34 @@ FinderGit is signed with **Apple Developer ID** and **notarized by Apple**, so G
 
 When you first launch any app downloaded from the internet, macOS shows a one-time confirmation dialog ("*"FinderGit" is an app downloaded from the Internet. Are you sure you want to open it?*"). Click **Open** and you're done — every subsequent launch is silent.
 
+## Verifying your download
+
+Every release is signed with an Apple Developer ID and notarized by Apple, so macOS is already checking the app's integrity on your behalf. If you'd rather confirm the DMG yourself, every [release page](https://github.com/gfazioli/findergit-website/releases/latest) publishes the SHA-256 of its DMG. Compare it against the file you downloaded:
+
+```
+shasum -a 256 FinderGit-<version>.dmg
+```
+
+You can also ask macOS directly, without installing anything:
+
+```
+spctl -a -vv -t open --context context:primary-signature FinderGit-<version>.dmg
+```
+
+A genuine build answers:
+
+```
+accepted
+source=Notarized Developer ID
+origin=Developer ID Application: Giovambattista Fazioli (QWWPDQNH5L)
+```
+
+### If a virus scanner flags the download
+
+Worth knowing why before you worry about it. Antivirus engines increasingly classify files with machine-learning heuristics instead of signatures of known malware, and those heuristics produce false positives on legitimate software — disk images and installers especially. Apple's notarization, by contrast, includes an automated malware scan that every FinderGit release passes before it is published.
+
+So: if a scanner flags a DMG whose SHA-256 matches the one on its release page, that is a heuristic false positive, and we report those to the vendor. If the checksum does **not** match, the file you have is not the one we shipped — please [tell us](mailto:feedback@findergit.app?subject=FinderGit%20download%20verification) and download it again from the release page.
+
 ## Before first launch (fresh Mac)
 
 FinderGit uses the `git` binary that ships with the Xcode Command Line Tools. On a brand-new Mac you may need to install them and accept the Xcode license — otherwise every Git action inside FinderGit will surface a `nonZeroExit(status: 89, …)` error.

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -22,19 +22,19 @@ When you first launch any app downloaded from the internet, macOS shows a one-ti
 Every release is signed with an Apple Developer ID and notarized by Apple, so macOS is already checking the app's integrity on your behalf. If you'd rather confirm the DMG yourself, every [release page](https://github.com/gfazioli/findergit-website/releases/latest) publishes the SHA-256 of its DMG. Compare it against the file you downloaded:
 
 ```
-shasum -a 256 FinderGit-<version>.dmg
+shasum -a 256 ~/Downloads/FinderGit-*.dmg
 ```
 
 You can also ask macOS directly, without installing anything:
 
 ```
-spctl -a -vv -t open --context context:primary-signature FinderGit-<version>.dmg
+spctl -a -vv -t open --context context:primary-signature ~/Downloads/FinderGit-*.dmg
 ```
 
-A genuine build answers:
+A genuine build answers with the file's own path, then:
 
 ```
-accepted
+/Users/you/Downloads/FinderGit-0.25.1.dmg: accepted
 source=Notarized Developer ID
 origin=Developer ID Application: Giovambattista Fazioli (QWWPDQNH5L)
 ```
@@ -43,7 +43,9 @@ origin=Developer ID Application: Giovambattista Fazioli (QWWPDQNH5L)
 
 Worth knowing why before you worry about it. Antivirus engines increasingly classify files with machine-learning heuristics instead of signatures of known malware, and those heuristics produce false positives on legitimate software — disk images and installers especially. Apple's notarization, by contrast, includes an automated malware scan that every FinderGit release passes before it is published.
 
-So: if a scanner flags a DMG whose SHA-256 matches the one on its release page, that is a heuristic false positive, and we report those to the vendor. If the checksum does **not** match, the file you have is not the one we shipped — please [tell us](mailto:feedback@findergit.app?subject=FinderGit%20download%20verification) and download it again from the release page.
+Be clear about what each check proves, though. A matching checksum tells you the file wasn't altered between our release page and your Mac; it cannot, on its own, tell you a detection is wrong. What makes a heuristic false positive the far likelier explanation is the three together: the bytes are the ones we published, Apple's notarization scan passed them, and `spctl` accepts them on your machine. When all three hold and a scanner still objects, that's one vendor's heuristic disagreeing with Apple's — and we report those.
+
+If any of them fail — the checksum differs, or `spctl` rejects the file — don't open it. The file you have is not the one we shipped: please [tell us](mailto:feedback@findergit.app?subject=FinderGit%20download%20verification) and download it again from the release page.
 
 ## Before first launch (fresh Mac)
 


### PR DESCRIPTION
A user emailed a VirusTotal page for `FinderGit-0.25.1.dmg` asking *"are you aware of this issue?"* — 1 engine of 61, Microsoft's `Trojan:Script/Wacatac.B!ml`, which is their machine-learning classifier rather than a signature match.

The file turned out to be **exactly** the DMG we published: SHA-256 `406e4ce5…ee0028`, byte-identical to the release asset, Developer ID signature valid, notarization ticket stapled, `spctl` reporting `source=Notarized Developer ID`. Every Mach-O inside it — the app binary plus the three updater helpers — is 0/62 on VirusTotal's own Relations tab; the flag is on the outer disk image only.

## Why this is a docs gap, not just a bad scan

Confirming that took reading the release asset digest out of the GitHub API by hand. Nobody reporting the next one can do that. The site said the app is *signed and notarized*, which tells a reader Gatekeeper is happy — but not whether the bytes they are holding are the bytes we published, which is the actual question when a scanner cries wolf.

So `getting-started` gets a **Verifying your download** section: the checksum comparison, the `spctl` invocation, the exact output a genuine build produces, and an honest paragraph on why heuristic false positives happen and what to do about them. The companion change in the app repo (`chore/publish-release-checksum`) makes `release.sh` publish the DMG's SHA-256 in every release body, so the digest this section tells people to compare against actually exists somewhere they can reach.

## Both commands were run, not written from memory

Against the published 0.25.1 DMG:

```
$ shasum -a 256 FinderGit-0.25.1.dmg
406e4ce5b251c4dd7ea58f94d507754e8dc51c0cfec7fff53cbe575e69ee0028

$ spctl -a -vv -t open --context context:primary-signature FinderGit-0.25.1.dmg
FinderGit-0.25.1.dmg: accepted
source=Notarized Developer ID
origin=Developer ID Application: Giovambattista Fazioli (QWWPDQNH5L)
```

The FAQ link target `#verifying-your-download` was checked against the rendered page, not assumed from the heading text.

## One judgement call worth reviewing

`components/FAQ/FAQ.tsx` also renders in the **homepage** accordion (`Welcome.tsx`), so this entry is not docs-only. It is therefore framed on *verification* rather than on antivirus — a visitor who wasn't worried shouldn't be handed the worry, while someone who arrives with it still finds the answer under either word. It also names no vendor and quotes no count ("1 of 61"), both of which would go stale the moment a definition update lands.

If you'd rather keep it off the homepage entirely, dropping the item from `FAQ.tsx` + `StructuredData.tsx` leaves the docs section standing on its own.

## Verified

`tsc --noEmit` clean · `oxlint` clean · `oxfmt --check` clean · `jest` 1/1 · `next build` exit 0 · served the production build and grepped the rendered HTML for the anchor id, both commands, the expected `spctl` output, the mailto, and the JSON-LD mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for verifying downloads with SHA-256 checksums.
  * Documented Apple signing and notarization checks, including expected macOS validation output.
  * Added troubleshooting advice for antivirus false positives and checksum mismatches.
  * Added an FAQ covering download security and how to report verification issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->