### PR TITLE
fix(release-notes): date each release by when it was published

### DIFF
--- a/components/ReleaseNotes/ReleaseNotes.tsx
+++ b/components/ReleaseNotes/ReleaseNotes.tsx
@@ -56,7 +56,7 @@ export function ReleaseNotes() {
             title={<Badge size="xl">{release.tag_name}</Badge>}
           >
             <Text size="sm" fw={800} mb={16}>
-              {release.created_at}
+              {release.displayDate}
             </Text>
             <MDXRemote compiledSource={release.body} components={components} />
           </Timeline.Item>

--- a/components/ReleaseNotes/format-release-date.test.ts
+++ b/components/ReleaseNotes/format-release-date.test.ts
@@ -1,0 +1,26 @@
+import { formatReleaseDate } from './format-release-date';
+
+// The suite runs in Pacific/Auckland (pinned in jest.global-setup.cjs, since a
+// beforeAll is too late to affect Intl). That zone is ahead of UTC, so the first
+// case below renders "August 20, 2026" without the UTC pin and this file goes
+// red. Under UTC — or under Europe/Rome, which agrees with UTC for these
+// timestamps — it would pass either way and prove nothing.
+describe('formatReleaseDate', () => {
+  it('keeps an afternoon-UTC publication on its own calendar date', () => {
+    // v0.26.0, published 16:40 UTC, which is already 20 August in Auckland.
+    expect(formatReleaseDate('2026-08-19T16:40:46Z', '2026-08-19T15:56:50Z')).toBe(
+      'August 19, 2026'
+    );
+  });
+
+  it('dates a release by publication, not by the commit its tag points at', () => {
+    // v0.25.0: tagged on a commit from 1 August, actually shipped on the 6th.
+    expect(formatReleaseDate('2026-08-06T09:08:57Z', '2026-08-01T17:24:23Z')).toBe(
+      'August 6, 2026'
+    );
+  });
+
+  it('falls back to the created date for a draft, which has no publication date', () => {
+    expect(formatReleaseDate(null, '2026-08-06T09:08:57Z')).toBe('August 6, 2026');
+  });
+});

--- a/components/ReleaseNotes/format-release-date.ts
+++ b/components/ReleaseNotes/format-release-date.ts
@@ -1,0 +1,25 @@
+/**
+ * The calendar date to show for a release.
+ *
+ * Two decisions, both of which were wrong on the live site:
+ *
+ * - `publishedAt`, never `createdAt`. GitHub reports `created_at` as the date of
+ *   the commit the tag points at, and the release script creates the GitHub
+ *   Release *before* it commits the appcast and config — so the tag lands on
+ *   whatever was last on `main`, which between releases is usually the previous
+ *   release's commit. v0.25.0 shipped on 6 August and the timeline dated it
+ *   1 August; five of the ten releases on the page were wrong this way.
+ *   `createdAt` stays as the fallback because a draft release has no
+ *   `published_at`.
+ * - Pinned to UTC. This is the calendar date of an event, not a local clock
+ *   reading, so it must not move with whoever is reading it: v0.26.0 was
+ *   published 16:40 UTC and renders as 20 August in New Zealand without this.
+ */
+export function formatReleaseDate(publishedAt: string | null, createdAt: string): string {
+  return new Date(publishedAt ?? createdAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/components/ReleaseNotes/use-release-notes.ts
+++ b/components/ReleaseNotes/use-release-notes.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { compileMdx } from 'nextra/compile';
 import useSWR from 'swr';
 
+import { formatReleaseDate } from './format-release-date';
+
 export interface Author {
   login: string;
   id: number;
@@ -38,7 +40,10 @@ export interface Release {
   draft: boolean;
   prerelease: boolean;
   created_at: string;
-  published_at: string;
+  /** Null on a draft release, which is why every read of it needs a fallback. */
+  published_at: string | null;
+  /** `published_at` formatted for display. Set by `useReleaseNotes`. */
+  displayDate?: string;
   assets: any[];
   tarball_url: string;
   zipball_url: string;
@@ -76,11 +81,7 @@ export function useReleaseNotes() {
         const releases = await Promise.all(
           data.releases.map(async (release) => ({
             ...release,
-            created_at: new Date(release.created_at).toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            }),
+            displayDate: formatReleaseDate(release.published_at, release.created_at),
             body: await compileMdx(release.body),
           }))
         );

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,6 +5,8 @@ const createJestConfig = nextJest({
 });
 
 const customJestConfig = {
+  // Pins the suite's time zone before any worker initialises ICU — see the file.
+  globalSetup: '<rootDir>/jest.global-setup.cjs',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
   moduleNameMapper: {
     '^@/components/(.*)$': '<rootDir>/components/$1',

--- a/jest.global-setup.cjs
+++ b/jest.global-setup.cjs
@@ -1,0 +1,15 @@
+// The test suite runs in a zone that is AHEAD of UTC, on purpose.
+//
+// Date bugs hide in a zone whose offset happens to agree with UTC for the
+// timestamps under test: Europe/Rome (UTC+2 in summer) renders a 16:40 UTC
+// publication on its own calendar date, so a formatter that forgot to pin a
+// zone still looked correct. Pacific/Auckland (UTC+12/+13) does not agree, and
+// the release-date tests fail without the pin.
+//
+// It has to be set here rather than in a `beforeAll`: by the time a test body
+// runs, the worker has already initialised ICU and re-reading process.env.TZ
+// has no effect on Intl (measured — resolvedOptions() kept reporting the
+// original zone). Workers inherit this env when they are forked.
+module.exports = async () => {
+  process.env.TZ = 'Pacific/Auckland';
+};


### PR DESCRIPTION
Cross-port of gfazioli/netfox-website#42. Same components, byte-identical before this change — so the same bug, just less visible.

## What was wrong here

Five of the ten releases on `/docs/release-notes` carried the wrong date:

| tag | shown | actually published |
|---|---|---|
| v0.26.0 | August 19 | August 19 ✅ |
| v0.25.1 | August 6 | August 6 ✅ |
| **v0.25.0** | **August 1** | **August 6** |
| **v0.24.0** | **July 29** | **July 31** |
| **v0.23.0** | **July 27** | **July 28** |
| **v0.22.0** | **July 11** | **July 14** |
| **v0.21.0** | **July 10** | **July 11** |

The timeline read `created_at`, which GitHub reports as the date of the commit the tag points at — and `release.sh` creates the GitHub Release *before* it commits the appcast and config, so the tag lands on whatever was last on `main`, usually the previous release's commit. The two most recent releases were tagged on same-day commits, which is the only reason the top of the page looked correct.

## Also: the date is pinned to UTC

A publication date is the calendar date of an event, not a local clock reading. v0.26.0 was published 16:40 UTC and renders as **20 August** in New Zealand without the pin.

The test file's zone is pinned in a `globalSetup`, not a `beforeAll`, and that detail is load-bearing: the first version of this test **passed with the fix removed**, because by the time a test body runs the worker has already initialised ICU and re-reading `process.env.TZ` does nothing to `Intl` — `resolvedOptions()` kept reporting `Europe/Rome`, which agrees with UTC for these timestamps. Pinned before the workers fork, deleting `timeZone: 'UTC'` turns the suite red (`Expected "August 19, 2026" / Received "August 20, 2026"`), verified by actually removing it.

## Deliberately NOT cross-ported

- **`config.app.minMacOS`** — it is `15.0` here and that is *correct*: FinderGit's `MACOSX_DEPLOYMENT_TARGET` really is 15.0. On netfox it was wrong (its floor is 15.6), and this value is where that wrong floor came from.
- **The roadmap version fix** — this site has no roadmap page.

## Verification

`oxfmt --check`, `tsc --noEmit`, `oxlint` all clean; jest **2 suites / 4 tests** green; `next build` green. The timeline renders client-side from SWR, so the dates are not in the served HTML — the transformation was checked against the real API payloads (the table above is measured).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release notes now display the publication date when available, with the creation date used as a fallback.
  * Dates are formatted consistently as full English calendar dates, regardless of timezone.

* **Tests**
  * Added coverage for publication-date priority, fallback behavior, and timezone-safe date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->