### PR TITLE
fix(ai-commit): ask Groq for a model it still serves, and watch that it does

### DIFF
--- a/app/api/ai-commit/health/route.ts
+++ b/app/api/ai-commit/health/route.ts
@@ -18,6 +18,11 @@ const GROQ_MODELS_URL = 'https://api.groq.com/openai/v1/models';
 // model list changes on the scale of weeks; 60 s of caching is invisible to a
 // monitor and bounds the fan-out.
 const CACHE_TTL_MS = 60 * 1000;
+// A monitor needs a verdict, not a hanging request: if Groq accepts the
+// connection and then stalls, an un-deadlined fetch turns "is the model
+// served?" into "the health check timed out", which is the same silence the
+// route was added to break. The signal covers reading the body too.
+const UPSTREAM_TIMEOUT_MS = 5000;
 let cached: { at: number; status: number; body: Record<string, unknown> } | null = null;
 
 function respond(status: number, body: Record<string, unknown>): Response {
@@ -43,6 +48,7 @@ export async function GET(): Promise<Response> {
   try {
     upstream = await fetch(GROQ_MODELS_URL, {
       headers: { Authorization: `Bearer ${process.env.GROQ_API_KEY}` },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
   } catch {
     return respond(503, { ok: false, reason: 'upstream_unreachable', model });
@@ -62,7 +68,10 @@ export async function GET(): Promise<Response> {
   let ids: string[];
   try {
     const json = (await upstream.json()) as { data?: Array<{ id?: unknown }> };
-    ids = (json.data ?? []).map((entry) => String(entry.id));
+    if (!Array.isArray(json.data)) {
+      throw new Error('no model list in the response');
+    }
+    ids = json.data.map((entry) => String(entry.id));
   } catch {
     return respond(503, { ok: false, reason: 'invalid_upstream_response', model });
   }

--- a/app/api/ai-commit/health/route.ts
+++ b/app/api/ai-commit/health/route.ts
@@ -1,0 +1,75 @@
+// Liveness check for the AI commit-message proxy.
+//
+// Exists because nothing was watching /api/ai-commit: Groq decommissioned the
+// model it asked for on 2026-08-16, every request had been failing since, and
+// we found out from a user eight days later (FinderGit#154). This route makes
+// that state machine-checkable -- point a monitor at it and the next
+// decommission is caught the day it lands, not the day someone complains.
+//
+// GET returns 200 only when the configured model is one Groq will actually
+// serve. Anything else is 503 with a `reason` that says which half is broken.
+
+import { resolveModel } from '../model';
+
+const GROQ_MODELS_URL = 'https://api.groq.com/openai/v1/models';
+
+// The check hits a third party, so a burst of requests (a monitor with a tight
+// interval, a crawler) shouldn't turn into a burst of upstream calls. Groq's
+// model list changes on the scale of weeks; 60 s of caching is invisible to a
+// monitor and bounds the fan-out.
+const CACHE_TTL_MS = 60 * 1000;
+let cached: { at: number; status: number; body: Record<string, unknown> } | null = null;
+
+function respond(status: number, body: Record<string, unknown>): Response {
+  cached = { at: Date.now(), status, body };
+  return Response.json(body, { status, headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function GET(): Promise<Response> {
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return Response.json(cached.body, {
+      status: cached.status,
+      headers: { 'Cache-Control': 'no-store', 'X-Health-Cache': 'hit' },
+    });
+  }
+
+  const model = resolveModel();
+
+  if (!process.env.GROQ_API_KEY) {
+    return respond(503, { ok: false, reason: 'missing_api_key', model });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(GROQ_MODELS_URL, {
+      headers: { Authorization: `Bearer ${process.env.GROQ_API_KEY}` },
+    });
+  } catch {
+    return respond(503, { ok: false, reason: 'upstream_unreachable', model });
+  }
+
+  if (!upstream.ok) {
+    // 401 here means the key itself is the problem, which is worth
+    // distinguishing from a model that has gone away.
+    return respond(503, {
+      ok: false,
+      reason: upstream.status === 401 ? 'invalid_api_key' : 'upstream_error',
+      status: upstream.status,
+      model,
+    });
+  }
+
+  let ids: string[];
+  try {
+    const json = (await upstream.json()) as { data?: Array<{ id?: unknown }> };
+    ids = (json.data ?? []).map((entry) => String(entry.id));
+  } catch {
+    return respond(503, { ok: false, reason: 'invalid_upstream_response', model });
+  }
+
+  if (!ids.includes(model)) {
+    return respond(503, { ok: false, reason: 'model_unavailable', model });
+  }
+
+  return respond(200, { ok: true, model });
+}

--- a/app/api/ai-commit/model.test.ts
+++ b/app/api/ai-commit/model.test.ts
@@ -53,6 +53,13 @@ describe('sanitizeMessage', () => {
     expect(sanitizeMessage(raw)).toBe(raw);
   });
 
+  it('strips an opening fence whatever its info string', () => {
+    // ```commit-message is a legal fence, and an alphabetic-only match stops at
+    // the hyphen -- leaving "-message" at the head of the commit message.
+    expect(sanitizeMessage('```commit-message\nfeat: add thing\n```')).toBe('feat: add thing');
+    expect(sanitizeMessage('```\nfeat: add thing\n```')).toBe('feat: add thing');
+  });
+
   it('still strips code fences and surrounding quotes', () => {
     expect(sanitizeMessage('```text\nfeat: add thing\n```')).toBe('feat: add thing');
     expect(sanitizeMessage('"fix: guard the nil case"')).toBe('fix: guard the nil case');

--- a/app/api/ai-commit/model.test.ts
+++ b/app/api/ai-commit/model.test.ts
@@ -1,0 +1,60 @@
+import { isReasoningModel, resolveModel, sanitizeMessage } from './model';
+
+// These are the rules that decide what lands in the user's commit field. The
+// `<think>` cases are the ones with teeth: with the tag-stripping removed,
+// they return the model's chain of thought as the commit message.
+describe('resolveModel', () => {
+  it('falls back to the default when GROQ_MODEL is unset, empty or whitespace', () => {
+    expect(resolveModel(undefined)).toBe('openai/gpt-oss-120b');
+    expect(resolveModel('')).toBe('openai/gpt-oss-120b');
+    expect(resolveModel('   ')).toBe('openai/gpt-oss-120b');
+  });
+
+  it('honours GROQ_MODEL so a decommission can be worked around from Vercel', () => {
+    expect(resolveModel('qwen/qwen3.6-27b')).toBe('qwen/qwen3.6-27b');
+    expect(resolveModel('  openai/gpt-oss-20b  ')).toBe('openai/gpt-oss-20b');
+  });
+});
+
+describe('isReasoningModel', () => {
+  it('recognises the reasoning families Groq accepts reasoning_format for', () => {
+    expect(isReasoningModel('openai/gpt-oss-120b')).toBe(true);
+    expect(isReasoningModel('openai/gpt-oss-20b')).toBe(true);
+    expect(isReasoningModel('qwen/qwen3.6-27b')).toBe(true);
+  });
+
+  it('leaves plain instruction models alone, since they 400 on the parameter', () => {
+    expect(isReasoningModel('llama-3.1-8b-instant')).toBe(false);
+    expect(isReasoningModel('llama-3.3-70b-versatile')).toBe(false);
+  });
+});
+
+describe('sanitizeMessage', () => {
+  it('drops a reasoning block and keeps the commit message after it', () => {
+    const raw =
+      '<think>\nThe diff adds a README line, so this is docs.\n</think>\ndocs: mention the new flag';
+    expect(sanitizeMessage(raw)).toBe('docs: mention the new flag');
+  });
+
+  it('returns nothing when the answer is reasoning cut off mid-thought', () => {
+    // The completion budget ran out inside the `<think>` block, so there is no
+    // message at all -- the caller must report a provider failure rather than
+    // paste half a thought into a commit.
+    expect(sanitizeMessage('<think>Let me look at what changed here and')).toBe('');
+  });
+
+  it('returns nothing when reasoning is all there was', () => {
+    expect(sanitizeMessage('<think>done thinking</think>')).toBe('');
+  });
+
+  it('keeps a bulleted body intact', () => {
+    const raw =
+      'chore: bump dependencies\n\n- Update Mantine to 9.1.1.\n- Upgrade Storybook to 10.3.6.';
+    expect(sanitizeMessage(raw)).toBe(raw);
+  });
+
+  it('still strips code fences and surrounding quotes', () => {
+    expect(sanitizeMessage('```text\nfeat: add thing\n```')).toBe('feat: add thing');
+    expect(sanitizeMessage('"fix: guard the nil case"')).toBe('fix: guard the nil case');
+  });
+});

--- a/app/api/ai-commit/model.ts
+++ b/app/api/ai-commit/model.ts
@@ -1,0 +1,65 @@
+// Model selection and output sanitising for the AI commit-message proxy.
+//
+// Split out of route.ts because these three rules decide what the user ends
+// up with in the commit field, and they are the parts worth unit-testing:
+// which model we ask for, whether that model needs a `reasoning_format`, and
+// what has to be stripped from its answer before we hand it back.
+
+// Groq decommissioned `llama-3.3-70b-versatile` on 2026-08-16 -- the model
+// this proxy had hardcoded since it shipped. Groq answered 404 to every
+// request and the app reported "provider temporarily unreachable" for eight
+// days (FinderGit#154). `openai/gpt-oss-120b` is Groq's own recommended
+// replacement for it.
+const DEFAULT_MODEL = 'openai/gpt-oss-120b';
+
+/// The model to ask Groq for. `GROQ_MODEL` on Vercel overrides the default,
+/// so the next decommission is a dashboard edit plus a redeploy rather than a
+/// code change, a review and a release.
+export function resolveModel(configured: string | undefined = process.env.GROQ_MODEL): string {
+  const trimmed = configured?.trim();
+  return trimmed ? trimmed : DEFAULT_MODEL;
+}
+
+// Reasoning models on Groq accept `reasoning_format`; the plain instruction
+// models reject it with a 400. Since `GROQ_MODEL` can point anywhere, decide
+// from the model id rather than assuming the default is still in place --
+// otherwise switching to a Llama-style model via the env var would break the
+// endpoint in a new way.
+const REASONING_MODEL_PATTERN = /gpt-oss|qwen3|deepseek-r1|magistral|kimi/i;
+
+export function isReasoningModel(model: string): boolean {
+  return REASONING_MODEL_PATTERN.test(model);
+}
+
+/// Cleans up the model's answer before it reaches the commit field.
+///
+/// Returns an empty string when nothing usable survives, which the caller
+/// must treat as a provider failure -- never as a commit message.
+export function sanitizeMessage(raw: string): string {
+  let text = raw.trim();
+
+  // Reasoning models emit their chain of thought in `<think>` tags inside
+  // `message.content` whenever `reasoning_format` is `raw`, which is Groq's
+  // default. We ask for `hidden`, so this is belt-and-braces: if the request
+  // ever goes out without the parameter (an env var pointing at a model our
+  // pattern above doesn't recognise, a Groq default change), the thinking
+  // must not land in the user's commit message.
+  text = text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+  // An unterminated `<think>` means the model spent its whole completion
+  // budget thinking and got cut off mid-thought. Everything after the tag is
+  // truncated reasoning, so there is no message here at all.
+  const unterminated = text.search(/<think>/i);
+  if (unterminated !== -1) {
+    text = text.slice(0, unterminated).trim();
+  }
+
+  // Code fences and surrounding quotes the model sometimes adds despite being
+  // told not to.
+  return text
+    .replace(/^```(?:[a-zA-Z]+)?\n?/, '')
+    .replace(/```$/, '')
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .trim();
+}

--- a/app/api/ai-commit/model.ts
+++ b/app/api/ai-commit/model.ts
@@ -55,9 +55,11 @@ export function sanitizeMessage(raw: string): string {
   }
 
   // Code fences and surrounding quotes the model sometimes adds despite being
-  // told not to.
+  // told not to. The opening fence is matched to the end of its line rather
+  // than by info-string alphabet: ```commit-message is a legal fence, and an
+  // alphabetic-only match would leave "-message" heading the commit message.
   return text
-    .replace(/^```(?:[a-zA-Z]+)?\n?/, '')
+    .replace(/^```[^\r\n]*(?:\r?\n|$)/, '')
     .replace(/```$/, '')
     .trim()
     .replace(/^["'`]+|["'`]+$/g, '')

--- a/app/api/ai-commit/route.ts
+++ b/app/api/ai-commit/route.ts
@@ -26,6 +26,11 @@ const MAX_DIFF_BYTES = 100_000;
 // and the app reports a provider failure. Sized to leave room for both.
 const MAX_TOKENS_SHORT = 1500;
 const MAX_TOKENS_LONG = 2500;
+// Deadline on the upstream call. The app gives up after 30 s, so answering
+// before that keeps the failure ours to describe -- a stalled Groq connection
+// otherwise surfaces as a bare client-side network error with nothing in our
+// logs to say what happened.
+const UPSTREAM_TIMEOUT_MS = 25_000;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const RATE_LIMIT_MAX = 30;
 
@@ -228,6 +233,7 @@ export async function POST(request: Request): Promise<Response> {
         Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
         'Content-Type': 'application/json',
       },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
       body: JSON.stringify({
         model,
         messages: [

--- a/app/api/ai-commit/route.ts
+++ b/app/api/ai-commit/route.ts
@@ -1,9 +1,11 @@
 // AI commit-message proxy used by the FinderGit macOS app.
 //
 // Flow: FinderGit POSTs a `git diff` plus a small config object; we forward
-// it to Groq with a system prompt and stream the result back. The Groq API
-// key lives only on Vercel (`GROQ_API_KEY`), so end-users never need to
-// configure anything to use the free Auto provider.
+// it to Groq with a system prompt and return the whole answer in one JSON
+// response (no streaming -- a commit message is one shot). The Groq API key
+// lives only on Vercel (`GROQ_API_KEY`), so end-users never need to configure
+// anything to use the free Auto provider. Which model we ask for is
+// `GROQ_MODEL`, defaulting to the value in ./model.ts.
 //
 // Limits we enforce here:
 // - 100 KB max diff size — keeps Groq token usage bounded and free-tier
@@ -13,9 +15,17 @@
 //   below); upgrade to Vercel KV or Upstash Redis when abuse becomes real
 // - Bot user-agent rejection — the same heuristic we use for github-releases
 
+import { isReasoningModel, resolveModel, sanitizeMessage } from './model';
+
 const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
-const GROQ_MODEL = 'llama-3.3-70b-versatile';
 const MAX_DIFF_BYTES = 100_000;
+// Completion budgets. A reasoning model bills its thinking against the same
+// budget even when we ask for `reasoning_format: hidden`, so a budget sized
+// for a plain instruction model (180 / 400, which is what shipped) leaves
+// nothing for the answer: the reply comes back empty or cut off mid-thought,
+// and the app reports a provider failure. Sized to leave room for both.
+const MAX_TOKENS_SHORT = 1500;
+const MAX_TOKENS_LONG = 2500;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const RATE_LIMIT_MAX = 30;
 
@@ -208,6 +218,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const config = parseConfig(body.config);
   const systemPrompt = buildSystemPrompt(config);
+  const model = resolveModel();
 
   let groqResponse: Response;
   try {
@@ -218,13 +229,17 @@ export async function POST(request: Request): Promise<Response> {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: GROQ_MODEL,
+        model,
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: body.diff },
         ],
         temperature: 0.3,
-        max_completion_tokens: config.length === 'long' ? 400 : 180,
+        max_completion_tokens: config.length === 'long' ? MAX_TOKENS_LONG : MAX_TOKENS_SHORT,
+        // Ask for the answer only. Groq's default `reasoning_format` is
+        // `raw`, which wraps the chain of thought in `<think>` tags inside
+        // `message.content` -- i.e. straight into the user's commit message.
+        ...(isReasoningModel(model) ? { reasoning_format: 'hidden' } : {}),
       }),
     });
   } catch (error: any) {
@@ -236,9 +251,26 @@ export async function POST(request: Request): Promise<Response> {
   if (!groqResponse.ok) {
     const text = await groqResponse.text().catch(() => '');
     // eslint-disable-next-line no-console
-    console.error('Groq returned non-2xx:', groqResponse.status, text);
+    console.error('Groq returned non-2xx:', model, groqResponse.status, text);
+
+    // A 4xx from Groq means OUR request is wrong -- a decommissioned model, a
+    // revoked key, an unsupported parameter -- and no amount of retrying will
+    // fix it. Reporting that as 502 is what let a dead model masquerade as a
+    // passing outage for eight days (FinderGit#154), so it gets its own status
+    // and a machine-readable code the client can act on.
+    if (groqResponse.status >= 400 && groqResponse.status < 500) {
+      return Response.json(
+        {
+          error: 'The AI service is misconfigured and needs an update. Please report this.',
+          code: 'upstream_request_rejected',
+          status: groqResponse.status,
+        },
+        { status: 424 }
+      );
+    }
+
     return Response.json(
-      { error: 'Upstream provider error', status: groqResponse.status },
+      { error: 'Upstream provider error', code: 'upstream_error', status: groqResponse.status },
       { status: 502 }
     );
   }
@@ -251,19 +283,24 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const message: unknown = groqJson?.choices?.[0]?.message?.content;
-  if (typeof message !== 'string' || message.trim().length === 0) {
+  if (typeof message !== 'string') {
     return Response.json({ error: 'Empty response from provider' }, { status: 502 });
   }
 
-  // Strip surrounding code fences or quotes the model sometimes adds despite
-  // being told not to. The TextField will display this verbatim.
-  const cleaned = message
-    .trim()
-    .replace(/^```(?:[a-zA-Z]+)?\n?/, '')
-    .replace(/```$/, '')
-    .trim()
-    .replace(/^["'`]+|["'`]+$/g, '')
-    .trim();
+  // The app displays this verbatim in the commit field, so the emptiness check
+  // belongs AFTER the cleanup: an answer that is nothing but a code fence, or
+  // nothing but truncated reasoning, must be reported as a failure rather than
+  // pasted into a commit.
+  const cleaned = sanitizeMessage(message);
+  if (cleaned.length === 0) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Nothing usable in the provider response:',
+      model,
+      JSON.stringify(message.slice(0, 300))
+    );
+    return Response.json({ error: 'Empty response from provider' }, { status: 502 });
+  }
 
   return Response.json({ message: cleaned });
 }


### PR DESCRIPTION
Fixes the dead AI commit-message feature reported in FinderGit#154, and closes the gap that let it stay dead for eight days.

## What was wrong

Groq decommissioned `llama-3.3-70b-versatile` on **2026-08-16** -- the model this route hardcoded. Measured against production before this branch:

```
POST https://findergit.app/api/ai-commit
-> HTTP 502  {"error":"Upstream provider error","status":404}
```

That `404` is Groq's. The route mapped any non-2xx upstream response to 502, and the app maps 502/503 to "The AI provider is temporarily unreachable. Try again in a moment." A permanent misconfiguration, reported as something that would pass on its own.

Not the API key: Groq validates auth first (a deliberately invalid key returns **401**, verified), and a missing key would have produced our own 503 `AI provider not configured`.

## What this changes

- **`GROQ_MODEL` env var**, defaulting to `openai/gpt-oss-120b` (Groq's recommended replacement). The next decommission is a dashboard edit plus a redeploy, not a PR.
- **`reasoning_format: 'hidden'`** on the upstream request. This is the part that makes the model swap safe rather than cosmetic: gpt-oss is a reasoning model and Groq's default format is `raw`, which wraps the chain of thought in `<think>` tags **inside `message.content`** -- straight into the commit field. Sent only for model ids in a reasoning family, because plain instruction models reject the parameter with a 400 and `GROQ_MODEL` can point anywhere.
- **`<think>` stripped anyway**, as defence in depth, and an answer that is *only* reasoning (or only a code fence) is now reported as a provider failure instead of being pasted into a commit. The emptiness check moved after the cleanup, where it belongs.
- **Completion budget 180/400 -> 1500/2500.** Reasoning is billed against the same budget, so the old numbers leave nothing for the answer: the reply comes back empty or cut off mid-thought.
- **Upstream 4xx now returns 424** with `code: 'upstream_request_rejected'`, separate from a genuine 5xx/network 502. Retrying does not fix our own request being wrong, and conflating the two is what hid this bug.
- **`GET /api/ai-commit/health`** returns 200 only when the configured model is in Groq's model list, and a `reason` when it is not (`missing_api_key`, `invalid_api_key`, `model_unavailable`, `upstream_error`, `upstream_unreachable`). Cached 60 s. Point a monitor at it.

## Tests

`app/api/ai-commit/model.test.ts` covers the two rules that decide what reaches the commit field. Verified they discriminate: with the `<think>` handling removed, 3 of the 9 go red, and the failing assertions are exactly the ones that would otherwise return the model's chain of thought as a commit message.

Full gate green locally: `oxfmt --check`, `oxlint`, `tsc --noEmit`, `jest` (13 tests).

## Still to verify on the preview deployment

The one thing local tests cannot answer is what Groq actually returns for the new model, since the key only exists on Vercel. Before merging, the preview URL needs a real request checked for three things: a 200, a subject line in the expected shape, and no `<think>` residue -- plus one `length=long` request to confirm the bulleted body survived the model change (the system prompt teaches that shape by example, and Llama mirrored the example closely; a different family may not).

## Follow-up in the app repo

`AICommitClient.defaultEndpoint` targets `www.findergit.app` and its comment says the apex 307-redirects there. That is now inverted: `www` returns **308** to the apex (measured 2026-08-24), so every AI request pays a redirect. Tracked in FinderGit#154 together with mapping 424 to a client error that says "needs an update" rather than "try again".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an AI commit-message service health check to indicate whether the configured model is available.
  - Added support for selecting the AI model through configuration.
  - Improved compatibility with reasoning-capable models.

- **Bug Fixes**
  - Removed internal reasoning, code fences, extra whitespace, and surrounding quotes from generated commit messages.
  - Improved error reporting when the AI service or model is unavailable.
  - Increased completion capacity for more reliable generated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->