### PR TITLE
fix(ai-commit): a spent Groq quota is not a broken service

### DIFF
--- a/app/api/ai-commit/model.test.ts
+++ b/app/api/ai-commit/model.test.ts
@@ -1,4 +1,4 @@
-import { isReasoningModel, resolveModel, sanitizeMessage } from './model';
+import { isReasoningModel, reasoningOptions, resolveModel, sanitizeMessage } from './model';
 
 // These are the rules that decide what lands in the user's commit field. The
 // `<think>` cases are the ones with teeth: with the tag-stripping removed,
@@ -26,6 +26,33 @@ describe('isReasoningModel', () => {
   it('leaves plain instruction models alone, since they 400 on the parameter', () => {
     expect(isReasoningModel('llama-3.1-8b-instant')).toBe(false);
     expect(isReasoningModel('llama-3.3-70b-versatile')).toBe(false);
+  });
+});
+
+describe('reasoningOptions', () => {
+  it('sends low effort only to the GPT-OSS family, which accepts those values', () => {
+    expect(reasoningOptions('openai/gpt-oss-120b')).toEqual({
+      reasoning_format: 'hidden',
+      reasoning_effort: 'low',
+    });
+    expect(reasoningOptions('openai/gpt-oss-20b')).toEqual({
+      reasoning_format: 'hidden',
+      reasoning_effort: 'low',
+    });
+  });
+
+  it('omits the effort for other reasoning families, which reject low', () => {
+    // Groq accepts only none/default for Qwen 3.6, and Qwen is the other
+    // replacement it recommends -- so sending `low` would break the GROQ_MODEL
+    // override exactly when it is being used to escape a dead model.
+    expect(reasoningOptions('qwen/qwen3.6-27b')).toEqual({ reasoning_format: 'hidden' });
+    expect(reasoningOptions('deepseek-r1-distill-llama-70b')).toEqual({
+      reasoning_format: 'hidden',
+    });
+  });
+
+  it('sends nothing at all for a plain instruction model', () => {
+    expect(reasoningOptions('llama-3.1-8b-instant')).toEqual({});
   });
 });
 

--- a/app/api/ai-commit/model.ts
+++ b/app/api/ai-commit/model.ts
@@ -31,6 +31,30 @@ export function isReasoningModel(model: string): boolean {
   return REASONING_MODEL_PATTERN.test(model);
 }
 
+// `reasoning_effort` is not one parameter across families: Groq accepts
+// low/medium/high for GPT-OSS and only none/default for Qwen 3.6. Sending
+// `low` to a Qwen model is a rejected request, which would break the
+// GROQ_MODEL override at the exact moment it is needed -- Qwen being the other
+// replacement Groq recommends for the model that was switched off.
+const EFFORT_CAPABLE_PATTERN = /gpt-oss/i;
+
+/// Reasoning parameters to merge into the upstream request for this model.
+///
+/// `reasoning_format: 'hidden'` for every reasoning family, because the
+/// default (`raw`) puts the chain of thought inside `message.content`.
+/// `reasoning_effort` only where its values are the ones Groq accepts.
+export function reasoningOptions(model: string): Record<string, string> {
+  if (!isReasoningModel(model)) {
+    return {};
+  }
+  if (EFFORT_CAPABLE_PATTERN.test(model)) {
+    // Summarising a diff is not a puzzle, and every reasoning token is billed
+    // against both our completion budget and the key's per-minute allowance.
+    return { reasoning_format: 'hidden', reasoning_effort: 'low' };
+  }
+  return { reasoning_format: 'hidden' };
+}
+
 /// Cleans up the model's answer before it reaches the commit field.
 ///
 /// Returns an empty string when nothing usable survives, which the caller

--- a/app/api/ai-commit/route.ts
+++ b/app/api/ai-commit/route.ts
@@ -15,7 +15,7 @@
 //   below); upgrade to Vercel KV or Upstash Redis when abuse becomes real
 // - Bot user-agent rejection — the same heuristic we use for github-releases
 
-import { isReasoningModel, resolveModel, sanitizeMessage } from './model';
+import { reasoningOptions, resolveModel, sanitizeMessage } from './model';
 
 const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
 const MAX_DIFF_BYTES = 100_000;
@@ -248,14 +248,10 @@ export async function POST(request: Request): Promise<Response> {
         ],
         temperature: 0.3,
         max_completion_tokens: config.length === 'long' ? MAX_TOKENS_LONG : MAX_TOKENS_SHORT,
-        // Ask for the answer only. Groq's default `reasoning_format` is
-        // `raw`, which wraps the chain of thought in `<think>` tags inside
-        // `message.content` -- i.e. straight into the user's commit message.
-        // `low` effort because summarising a diff is not a puzzle: reasoning
-        // tokens are billed against both our completion budget and the key's
-        // per-minute token allowance, and that allowance is what ran out
-        // during the production check of the model swap.
-        ...(isReasoningModel(model) ? { reasoning_format: 'hidden', reasoning_effort: 'low' } : {}),
+        // Reasoning parameters, chosen per model family -- see ./model.ts.
+        // Without them the chain of thought arrives inside `message.content`,
+        // i.e. in the user's commit message.
+        ...reasoningOptions(model),
       }),
     });
   } catch (error: any) {
@@ -309,9 +305,20 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const remainingTokens = Number(groqResponse.headers.get('x-ratelimit-remaining-tokens'));
-  if (Number.isFinite(remainingTokens) && remainingTokens < 2000) {
+  const limitTokens = Number(groqResponse.headers.get('x-ratelimit-limit-tokens'));
+  // A quarter of whatever this model's per-minute allowance actually is: a
+  // fixed number means something different on every plan and every model.
+  const warnBelow = Number.isFinite(limitTokens) && limitTokens > 0 ? limitTokens * 0.25 : 2000;
+  if (Number.isFinite(remainingTokens) && remainingTokens < warnBelow) {
     // eslint-disable-next-line no-console
-    console.warn('Groq token allowance nearly spent:', remainingTokens, 'tokens left', model);
+    console.warn(
+      'Groq token allowance nearly spent:',
+      remainingTokens,
+      'of',
+      Number.isFinite(limitTokens) ? limitTokens : 'unknown',
+      'left for',
+      model
+    );
   }
 
   let groqJson: any;

--- a/app/api/ai-commit/route.ts
+++ b/app/api/ai-commit/route.ts
@@ -23,9 +23,15 @@ const MAX_DIFF_BYTES = 100_000;
 // budget even when we ask for `reasoning_format: hidden`, so a budget sized
 // for a plain instruction model (180 / 400, which is what shipped) leaves
 // nothing for the answer: the reply comes back empty or cut off mid-thought,
-// and the app reports a provider failure. Sized to leave room for both.
-const MAX_TOKENS_SHORT = 1500;
-const MAX_TOKENS_LONG = 2500;
+// and the app reports a provider failure.
+//
+// The numbers come from what the model actually returns -- measured in
+// production, a `length=long` answer is a subject line plus five bullets,
+// roughly 180 tokens -- kept well clear of that, but no further: Groq's free
+// tier allows 8 K tokens per minute for the whole key, shared by every user of
+// the app, so headroom we ask for and never use still costs us throughput.
+const MAX_TOKENS_SHORT = 800;
+const MAX_TOKENS_LONG = 1600;
 // Deadline on the upstream call. The app gives up after 30 s, so answering
 // before that keeps the failure ours to describe -- a stalled Groq connection
 // otherwise surfaces as a bare client-side network error with nothing in our
@@ -245,7 +251,11 @@ export async function POST(request: Request): Promise<Response> {
         // Ask for the answer only. Groq's default `reasoning_format` is
         // `raw`, which wraps the chain of thought in `<think>` tags inside
         // `message.content` -- i.e. straight into the user's commit message.
-        ...(isReasoningModel(model) ? { reasoning_format: 'hidden' } : {}),
+        // `low` effort because summarising a diff is not a puzzle: reasoning
+        // tokens are billed against both our completion budget and the key's
+        // per-minute token allowance, and that allowance is what ran out
+        // during the production check of the model swap.
+        ...(isReasoningModel(model) ? { reasoning_format: 'hidden', reasoning_effort: 'low' } : {}),
       }),
     });
   } catch (error: any) {
@@ -259,11 +269,28 @@ export async function POST(request: Request): Promise<Response> {
     // eslint-disable-next-line no-console
     console.error('Groq returned non-2xx:', model, groqResponse.status, text);
 
-    // A 4xx from Groq means OUR request is wrong -- a decommissioned model, a
-    // revoked key, an unsupported parameter -- and no amount of retrying will
-    // fix it. Reporting that as 502 is what let a dead model masquerade as a
-    // passing outage for eight days (FinderGit#154), so it gets its own status
-    // and a machine-readable code the client can act on.
+    // Groq's own rate limit. The only 4xx that really does clear on its own,
+    // so it must not fall into the branch below: measured in production, a
+    // spent Groq quota was being reported as "the AI service needs an update",
+    // which is the same class of wrong advice -- in the other direction -- as
+    // the bug this endpoint was just fixed for. Pass it through as a 429 so
+    // the app says how long to wait, honouring Groq's own Retry-After when it
+    // sends one.
+    if (groqResponse.status === 429) {
+      const upstreamRetry = Number(groqResponse.headers.get('retry-after'));
+      const retryAfterSec =
+        Number.isFinite(upstreamRetry) && upstreamRetry > 0 ? Math.ceil(upstreamRetry) : 60;
+      return Response.json(
+        { error: 'Rate limit exceeded', code: 'upstream_rate_limited', retryAfter: retryAfterSec },
+        { status: 429, headers: { 'Retry-After': String(retryAfterSec) } }
+      );
+    }
+
+    // Any other 4xx from Groq means OUR request is wrong -- a decommissioned
+    // model, a revoked key, an unsupported parameter -- and no amount of
+    // retrying will fix it. Reporting that as 502 is what let a dead model
+    // masquerade as a passing outage for eight days (FinderGit#154), so it
+    // gets its own status and a machine-readable code the client can act on.
     if (groqResponse.status >= 400 && groqResponse.status < 500) {
       return Response.json(
         {
@@ -279,6 +306,12 @@ export async function POST(request: Request): Promise<Response> {
       { error: 'Upstream provider error', code: 'upstream_error', status: groqResponse.status },
       { status: 502 }
     );
+  }
+
+  const remainingTokens = Number(groqResponse.headers.get('x-ratelimit-remaining-tokens'));
+  if (Number.isFinite(remainingTokens) && remainingTokens < 2000) {
+    // eslint-disable-next-line no-console
+    console.warn('Groq token allowance nearly spent:', remainingTokens, 'tokens left', model);
   }
 
   let groqJson: any;


### PR DESCRIPTION
Follow-up to #45, from checking it against production rather than trusting it. Small, but it fixes a wrong message I had just introduced.

## What the check found

The model swap works. `length=short` and `length=long` both came back clean on a real 3 KB diff:

```
feat(ai-commit): add model resolution and sanitization

feat(ai-commit): add model resolution and message sanitization utilities

- Introduce default model fallback to handle Groq's decommissioned llama model...
- Allow model selection via `GROQ_MODEL` environment variable...
  [five bullets]
```

No `<think>` residue, no fences, no wrapping quotes, subject 54 and 72 chars, bulleted body intact. The guard rails still answer correctly too: 400 on an empty diff, 413 at 100 KB + 1, 400 with no user agent, 403 for a bot UA, and the `www` -> 308 -> apex path still delivers the POST body, which is what installed versions take.

Then the third and fourth requests came back **424 "The AI service is misconfigured and needs an update"** -- because Groq had answered **429**. Four requests in a row had spent the key's per-minute token allowance, and #45's new 4xx branch swept that in with decommissioned models and revoked keys.

That is the same mistake as the original bug, in the opposite direction: telling someone to report a permanent defect about something that clears on its own. Measured: a retry 30 s later returned 200.

## Changes

- **429 passes through as 429**, with Groq's `Retry-After` when it sends one, falling back to 60 s. The app already maps 429 to "try again in N s", so installed versions get the right message with no update.
- **`reasoning_effort: 'low'`** -- summarising a diff is not a puzzle, and reasoning tokens are billed against both our completion budget and the allowance.
- **Completion ceilings 1500/2500 -> 800/1600.** Groq's free tier is 8 K tokens per *minute* for the whole key, shared by every user of the app, and a real `length=long` answer measures ~180 tokens. The old ceilings were headroom bought with throughput.
- **A log line when the remaining token allowance drops under 2 K**, so the ceiling appears in the logs before it appears in a support report.

## Worth knowing, beyond this PR

That 8 K/minute is shared across everyone using the app, so a handful of simultaneous users can rate-limit each other, and the app will now correctly tell them to wait. #54 (bring your own key) is the real fix for that, and this makes the case for it concrete rather than theoretical.

Gate green: oxfmt, oxlint, tsc, 14 jest tests.
