### PR TITLE
fix(ai-commit): the sanitiser was calibrated for the wrong model family

### DIFF
--- a/app/api/ai-commit/health/route.ts
+++ b/app/api/ai-commit/health/route.ts
@@ -15,9 +15,12 @@ const GROQ_MODELS_URL = 'https://api.groq.com/openai/v1/models';
 
 // The check hits a third party, so a burst of requests (a monitor with a tight
 // interval, a crawler) shouldn't turn into a burst of upstream calls. Groq's
-// model list changes on the scale of weeks; 60 s of caching is invisible to a
-// monitor and bounds the fan-out.
-const CACHE_TTL_MS = 60 * 1000;
+// model list changes on the scale of weeks, and `/v1/models` spends the key's
+// requests-per-minute budget -- the same budget message generation needs -- so
+// this window is deliberately wider than a monitor's interval. Note the cache
+// is per lambda instance, so a warm region can still make one call per instance
+// per window.
+const CACHE_TTL_MS = 5 * 60 * 1000;
 // A monitor needs a verdict, not a hanging request: if Groq accepts the
 // connection and then stalls, an un-deadlined fetch turns "is the model
 // served?" into "the health check timed out", which is the same silence the

--- a/app/api/ai-commit/model.test.ts
+++ b/app/api/ai-commit/model.test.ts
@@ -57,21 +57,46 @@ describe('reasoningOptions', () => {
 });
 
 describe('sanitizeMessage', () => {
-  it('drops a reasoning block and keeps the commit message after it', () => {
+  it('drops a matched reasoning block and keeps the commit message after it', () => {
     const raw =
       '<think>\nThe diff adds a README line, so this is docs.\n</think>\ndocs: mention the new flag';
     expect(sanitizeMessage(raw)).toBe('docs: mention the new flag');
   });
 
+  it('drops reasoning whose opening tag never arrived', () => {
+    // Some providers emit only the closing tag; everything before it is
+    // thinking, and returning it would put the model's reasoning in a commit.
+    expect(sanitizeMessage('Let me analyse the diff.\n</think>\nfeat: add thing')).toBe(
+      'feat: add thing'
+    );
+  });
+
   it('returns nothing when the answer is reasoning cut off mid-thought', () => {
-    // The completion budget ran out inside the `<think>` block, so there is no
-    // message at all -- the caller must report a provider failure rather than
-    // paste half a thought into a commit.
     expect(sanitizeMessage('<think>Let me look at what changed here and')).toBe('');
   });
 
   it('returns nothing when reasoning is all there was', () => {
     expect(sanitizeMessage('<think>done thinking</think>')).toBe('');
+  });
+
+  it('takes the final channel out of GPT-OSS Harmony output', () => {
+    // The family this endpoint defaults to does not use <think> at all.
+    const raw =
+      '<|start|>assistant<|channel|>analysis<|message|>weighing the diff<|end|>' +
+      '<|start|>assistant<|channel|>final<|message|>fix: guard the nil case<|return|>';
+    expect(sanitizeMessage(raw)).toBe('fix: guard the nil case');
+  });
+
+  it('refuses Harmony output with no final channel rather than guessing', () => {
+    expect(sanitizeMessage('<|channel|>analysis<|message|>thinking out loud<|end|>feat: y')).toBe(
+      ''
+    );
+  });
+
+  it('refuses a message that still carries a marker, at the cost of a retry', () => {
+    // A legitimate message mentioning the marker literally is refused too. That
+    // costs one retry; guessing costs a commit with reasoning inside it.
+    expect(sanitizeMessage('feat: x\n\n- explains <think> tags in the parser')).toBe('');
   });
 
   it('keeps a bulleted body intact', () => {
@@ -81,8 +106,6 @@ describe('sanitizeMessage', () => {
   });
 
   it('strips an opening fence whatever its info string', () => {
-    // ```commit-message is a legal fence, and an alphabetic-only match stops at
-    // the hyphen -- leaving "-message" at the head of the commit message.
     expect(sanitizeMessage('```commit-message\nfeat: add thing\n```')).toBe('feat: add thing');
     expect(sanitizeMessage('```\nfeat: add thing\n```')).toBe('feat: add thing');
   });

--- a/app/api/ai-commit/model.ts
+++ b/app/api/ai-commit/model.ts
@@ -57,35 +57,67 @@ export function reasoningOptions(model: string): Record<string, string> {
 
 /// Cleans up the model's answer before it reaches the commit field.
 ///
-/// Returns an empty string when nothing usable survives, which the caller
-/// must treat as a provider failure -- never as a commit message.
+/// Returns an empty string when nothing usable survives, which the caller must
+/// treat as a provider failure -- never as a commit message. That includes
+/// anything still carrying a reasoning marker after the passes below: a commit
+/// message the user has to notice and undo is worse than an error they can
+/// retry, so this refuses rather than guesses.
 export function sanitizeMessage(raw: string): string {
   let text = raw.trim();
 
-  // Reasoning models emit their chain of thought in `<think>` tags inside
-  // `message.content` whenever `reasoning_format` is `raw`, which is Groq's
-  // default. We ask for `hidden`, so this is belt-and-braces: if the request
-  // ever goes out without the parameter (an env var pointing at a model our
-  // pattern above doesn't recognise, a Groq default change), the thinking
-  // must not land in the user's commit message.
+  // Reasoning arrives in `message.content` whenever `reasoning_format` is
+  // `raw`, which is Groq's default. We ask for `hidden`, so everything here is
+  // belt-and-braces for the day that request goes out without the parameter --
+  // a GROQ_MODEL the family check does not recognise, a provider default
+  // change -- because the cost of being wrong is the model's private thinking
+  // in a public commit.
+
+  // Matched pairs first.
   text = text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
 
-  // An unterminated `<think>` means the model spent its whole completion
-  // budget thinking and got cut off mid-thought. Everything after the tag is
-  // truncated reasoning, so there is no message here at all.
-  const unterminated = text.search(/<think>/i);
-  if (unterminated !== -1) {
-    text = text.slice(0, unterminated).trim();
+  // A closing tag with no opening one: the opening was truncated in transit or
+  // never emitted (some providers only send the close). Everything before it is
+  // reasoning, so keep what follows the last one.
+  const CLOSE = '</think>';
+  const lastClose = text.toLowerCase().lastIndexOf(CLOSE);
+  if (lastClose !== -1) {
+    text = text.slice(lastClose + CLOSE.length).trim();
+  }
+
+  // GPT-OSS -- the family this endpoint now defaults to -- does not use
+  // `<think>` at all: its native format is Harmony channels, where the answer
+  // is the `final` channel and the thinking is `analysis`. Take the final
+  // channel when it is there; when only other channels are present there is no
+  // way to tell answer from thinking, so leave the markers in place and let the
+  // refusal below catch it.
+  if (/<\|channel\|>/i.test(text)) {
+    const final = text.match(
+      /<\|channel\|>final<\|message\|>([\s\S]*?)(?:<\|return\|>|<\|end\|>|$)/i
+    );
+    if (final) {
+      text = final[1].trim();
+    }
   }
 
   // Code fences and surrounding quotes the model sometimes adds despite being
   // told not to. The opening fence is matched to the end of its line rather
   // than by info-string alphabet: ```commit-message is a legal fence, and an
   // alphabetic-only match would leave "-message" heading the commit message.
-  return text
+  const cleaned = text
     .replace(/^```[^\r\n]*(?:\r?\n|$)/, '')
     .replace(/```$/, '')
     .trim()
     .replace(/^["'`]+|["'`]+$/g, '')
     .trim();
+
+  // Still a marker in there? Either the model spent its whole budget thinking
+  // and got cut off mid-thought, or the answer is in a shape we do not
+  // recognise. Refuse. This also refuses the rare legitimate message that
+  // mentions a marker literally -- the trade is deliberate: that costs one
+  // retry, while guessing costs a commit with reasoning in it.
+  if (/<think|<\|/i.test(cleaned)) {
+    return '';
+  }
+
+  return cleaned;
 }

--- a/app/api/ai-commit/route.ts
+++ b/app/api/ai-commit/route.ts
@@ -16,6 +16,7 @@
 // - Bot user-agent rejection — the same heuristic we use for github-releases
 
 import { reasoningOptions, resolveModel, sanitizeMessage } from './model';
+import { classifyUpstreamFailure } from './upstream';
 
 const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
 const MAX_DIFF_BYTES = 100_000;
@@ -265,60 +266,50 @@ export async function POST(request: Request): Promise<Response> {
     // eslint-disable-next-line no-console
     console.error('Groq returned non-2xx:', model, groqResponse.status, text);
 
-    // Groq's own rate limit. The only 4xx that really does clear on its own,
-    // so it must not fall into the branch below: measured in production, a
-    // spent Groq quota was being reported as "the AI service needs an update",
-    // which is the same class of wrong advice -- in the other direction -- as
-    // the bug this endpoint was just fixed for. Pass it through as a 429 so
-    // the app says how long to wait, honouring Groq's own Retry-After when it
-    // sends one.
-    if (groqResponse.status === 429) {
-      const upstreamRetry = Number(groqResponse.headers.get('retry-after'));
-      const retryAfterSec =
-        Number.isFinite(upstreamRetry) && upstreamRetry > 0 ? Math.ceil(upstreamRetry) : 60;
-      return Response.json(
-        { error: 'Rate limit exceeded', code: 'upstream_rate_limited', retryAfter: retryAfterSec },
-        { status: 429, headers: { 'Retry-After': String(retryAfterSec) } }
-      );
+    switch (classifyUpstreamFailure(groqResponse.status)) {
+      // The only 4xx that clears on its own. Measured in production, a spent
+      // Groq allowance was being reported as "the AI service needs an update",
+      // which is the same class of wrong advice -- in the other direction -- as
+      // the bug this endpoint was fixed for. Pass it through as a 429 so the
+      // app says how long to wait, honouring Groq's own Retry-After.
+      case 'rate_limited': {
+        const upstreamRetry = Number(groqResponse.headers.get('retry-after'));
+        const retryAfterSec =
+          Number.isFinite(upstreamRetry) && upstreamRetry > 0 ? Math.ceil(upstreamRetry) : 60;
+        return Response.json(
+          {
+            error: 'Rate limit exceeded',
+            code: 'upstream_rate_limited',
+            retryAfter: retryAfterSec,
+          },
+          { status: 429, headers: { 'Retry-After': String(retryAfterSec) } }
+        );
+      }
+
+      // Our request is wrong -- a decommissioned model, a revoked key, an
+      // unsupported parameter -- and no amount of retrying will fix it.
+      // Reporting that as 502 is what let a dead model masquerade as a passing
+      // outage for eight days (FinderGit#154).
+      case 'request_rejected':
+        return Response.json(
+          {
+            error: 'The AI service is misconfigured and needs an update. Please report this.',
+            code: 'upstream_request_rejected',
+            status: groqResponse.status,
+          },
+          { status: 424 }
+        );
+
+      case 'provider_error':
+        return Response.json(
+          {
+            error: 'Upstream provider error',
+            code: 'upstream_error',
+            status: groqResponse.status,
+          },
+          { status: 502 }
+        );
     }
-
-    // Any other 4xx from Groq means OUR request is wrong -- a decommissioned
-    // model, a revoked key, an unsupported parameter -- and no amount of
-    // retrying will fix it. Reporting that as 502 is what let a dead model
-    // masquerade as a passing outage for eight days (FinderGit#154), so it
-    // gets its own status and a machine-readable code the client can act on.
-    if (groqResponse.status >= 400 && groqResponse.status < 500) {
-      return Response.json(
-        {
-          error: 'The AI service is misconfigured and needs an update. Please report this.',
-          code: 'upstream_request_rejected',
-          status: groqResponse.status,
-        },
-        { status: 424 }
-      );
-    }
-
-    return Response.json(
-      { error: 'Upstream provider error', code: 'upstream_error', status: groqResponse.status },
-      { status: 502 }
-    );
-  }
-
-  const remainingTokens = Number(groqResponse.headers.get('x-ratelimit-remaining-tokens'));
-  const limitTokens = Number(groqResponse.headers.get('x-ratelimit-limit-tokens'));
-  // A quarter of whatever this model's per-minute allowance actually is: a
-  // fixed number means something different on every plan and every model.
-  const warnBelow = Number.isFinite(limitTokens) && limitTokens > 0 ? limitTokens * 0.25 : 2000;
-  if (Number.isFinite(remainingTokens) && remainingTokens < warnBelow) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Groq token allowance nearly spent:',
-      remainingTokens,
-      'of',
-      Number.isFinite(limitTokens) ? limitTokens : 'unknown',
-      'left for',
-      model
-    );
   }
 
   let groqJson: any;

--- a/app/api/ai-commit/upstream.test.ts
+++ b/app/api/ai-commit/upstream.test.ts
@@ -1,0 +1,27 @@
+import { classifyUpstreamFailure } from './upstream';
+
+// This function exists because both of its wrong answers have already shipped:
+// a decommissioned model read as a transient outage, then a spent rate limit
+// read as a broken service.
+describe('classifyUpstreamFailure', () => {
+  it('treats 429 as transient, not as a broken request', () => {
+    expect(classifyUpstreamFailure(429)).toBe('rate_limited');
+  });
+
+  it('treats every other 4xx as our request being wrong', () => {
+    for (const status of [400, 401, 403, 404, 413, 422]) {
+      expect(classifyUpstreamFailure(status)).toBe('request_rejected');
+    }
+  });
+
+  it('treats 5xx as the provider being unwell', () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(classifyUpstreamFailure(status)).toBe('provider_error');
+    }
+  });
+
+  it('falls back to provider_error for a status that makes no sense', () => {
+    expect(classifyUpstreamFailure(0)).toBe('provider_error');
+    expect(classifyUpstreamFailure(999)).toBe('provider_error');
+  });
+});

--- a/app/api/ai-commit/upstream.ts
+++ b/app/api/ai-commit/upstream.ts
@@ -1,0 +1,28 @@
+// How to read a failed response from the AI provider.
+//
+// Its own file because getting this wrong is the whole history of this
+// endpoint: for eight days a decommissioned model was reported as a passing
+// outage (FinderGit#154), and the fix for that immediately reported a spent
+// rate limit as a broken service. Both were one-line decisions buried in a
+// request handler with no test. Here they are a function with a test.
+
+export type UpstreamFailure =
+  /// Transient by definition: the allowance refills. Pass it to the client as a
+  /// 429 so the app can say how long to wait.
+  | 'rate_limited'
+  /// The provider rejected the request WE built -- decommissioned model, bad
+  /// key, unsupported parameter. Retrying cannot help; the service needs a fix.
+  | 'request_rejected'
+  /// The provider itself is unwell (5xx), or the status makes no sense. Worth
+  /// retrying.
+  | 'provider_error';
+
+export function classifyUpstreamFailure(status: number): UpstreamFailure {
+  if (status === 429) {
+    return 'rate_limited';
+  }
+  if (status >= 400 && status < 500) {
+    return 'request_rejected';
+  }
+  return 'provider_error';
+}

--- a/content/ai-commit-messages.mdx
+++ b/content/ai-commit-messages.mdx
@@ -99,19 +99,21 @@ Your staged diff is sent to the AI in-flight only — **diffs are not logged or 
 |---|---|
 | Max diff size per request | 100 KB |
 | Max custom instructions length | 2 KB |
-| Rate limit | 30 requests / hour per IP |
+| Rate limit, per IP | 30 requests / hour |
+| Shared capacity | a few requests per minute, across everyone using the free mode |
 
 If you stage more than 100 KB of diff, the AI button surfaces an inline message asking you to stage fewer files — typically a sign that the commit is large enough to deserve splitting into multiple commits anyway.
 
-If you hit the per-IP rate limit (rare in normal use), the error banner shows a *retry-after* hint.
+The per-IP limit is rarely what you'll meet. The one you can actually run into is the **shared capacity**: the free mode runs on one pool for all users, so a burst of activity — yours or anyone else's — can briefly leave nothing in the tank, even on your first request of the day. When that happens the error banner tells you how many seconds to wait, and the wait is usually seconds rather than minutes. *Bring Your Own Key* (below) removes the shared pool from the picture entirely.
 
 ## Troubleshooting
 
 - **Button is disabled** — nothing is staged. Stage at least one file.
 - **"AI provider is temporarily unreachable"** — transient network glitch or warm-up delay. Click the **×** to dismiss the banner and retry; usually works on the second attempt.
+- **"The AI service needs an update"** — not something a retry fixes: the service behind the free mode needs attention on our side. Please [open an issue](https://github.com/gfazioli/findergit-website/issues/new) so it gets looked at.
 - **"Diff too large (max 100 KB)"** — stage fewer files, or split the change into multiple commits.
-- **"Hit the AI rate limit"** — wait the indicated number of seconds and try again. The 30/hour limit resets per IP.
+- **"Hit the AI rate limit"** — wait the number of seconds the banner names and try again. This is usually the shared capacity of the free mode rather than your own 30/hour allowance, so it often clears in seconds even if you have barely used the feature.
 
 ## Coming next
 
-The current implementation is **Phase 1**: the free zero-setup mode that just works. **Phase 2** (planned) adds *Bring Your Own Key* support — pick your preferred AI provider, supply your own API key (stored in macOS Keychain), and FinderGit calls that provider directly. Useful for privacy-sensitive repositories or to bypass the per-IP rate limit on the free tier.
+The current implementation is **Phase 1**: the free zero-setup mode that just works. **Phase 2** (planned) adds *Bring Your Own Key* support — pick your preferred AI provider, supply your own API key (stored in macOS Keychain), and FinderGit calls that provider directly. Useful for privacy-sensitive repositories, or to stop sharing capacity with every other user of the free mode.


### PR DESCRIPTION
A critical pass over my own two merged PRs, plus the one documentation claim they invalidated. Everything here was reproduced as a failing test before it was fixed.

## Three holes in the sanitiser

The function whose entire job is keeping the model's private thinking out of a public commit message. I tested it against the inputs I had imagined, which is how all three of these survived:

| input | before | after |
|---|---|---|
| `Let me analyse.\n</think>\nfeat: x` | returned **the whole thing**, reasoning included | `feat: x` |
| `feat: x\n\n- explains <think> tags` | silently truncated to `feat: x\n\n- explains` | refused |
| `<\|channel\|>analysis<\|message\|>...` | passed through untouched | refused |

The third is the embarrassing one. `<think>` tags are how DeepSeek and Qwen mark reasoning. **GPT-OSS -- the family this endpoint now defaults to -- uses Harmony channels**, so the guard was calibrated against every model except the one in production. Harmony output now has its `final` channel extracted, and output carrying markers we cannot interpret is refused rather than salvaged.

That refusal also catches the rare legitimate message that mentions a marker literally. Deliberate trade: a refusal costs one click, and a wrong commit message costs an amend that someone has to notice first.

## The upstream decision now has a test

`classifyUpstreamFailure` in `upstream.ts`. Both of its wrong answers have shipped once each in the last few hours -- a decommissioned model read as a transient outage (#45 fixed that), then a spent rate limit read as a broken service (#46 fixed that) -- and neither time was there a test, because the decision lived inline in the request handler. Now: 429 is transient, other 4xx is our request being wrong, everything else is the provider.

## Two smaller things

- The health route's cache window goes 60 s -> 5 min. `/v1/models` spends the key's requests-per-minute budget, which is the same budget message generation needs, and the cache was the only thing bounding that. Still per-lambda, so a warm region makes one call per instance per window -- noted in the comment rather than pretended away.
- `content/ai-commit-messages.mdx` claimed one rate limit, "30 requests / hour per IP", and called hitting it rare. The limit that actually bites is the shared capacity of the free mode -- one pool for every user -- so someone can be told to wait on their first request of the day while the docs say that cannot happen. Now stated plainly, without naming the plumbing, along with the "needs an update" error the client can now show.

## Gate

oxfmt, oxlint, tsc, **25 jest tests** (was 17). The three sanitiser cases fail on the previous implementation, which is how they were written.

## Known limits, stated rather than fixed

- `route.ts` still has no test of its own: what is covered is the pure logic it calls. Testing the handler needs `Request`/`Response` plumbing in jsdom, which is a bigger change than this PR should carry.
- `/api/ai-commit/health` proves the model is *listed*, not that it *answers*. Checking that it answers would spend tokens from the shared pool on every poll, which is the wrong trade for a monitor.
- The low-allowance warning reads `x-ratelimit-limit-tokens`; I have not confirmed Groq sends that header on 2xx responses, since it is only visible in the Vercel logs. If it is absent the threshold falls back to a fixed 2 K, which is the previous behaviour.
