### PR TITLE
docs: Codeberg support (hold until the app release ships it)

### DIFF
--- a/content/detail-panel.mdx
+++ b/content/detail-panel.mdx
@@ -44,7 +44,7 @@ The Overview tab paints the forge-side identity of the repo — GitHub or Codebe
 
 If the selected repo doesn't have a GitHub remote (or the panel can't reach GitHub), the section silently disappears and the tab shows a short hint pointing at where the operational view moved.
 
-See [GitHub Integration](/docs/github-integration) for how to enable the GitHub-driven tabs.
+See [GitHub Integration](/docs/github-integration) for how to enable these tabs on GitHub, and what Codeberg fills in without any setup.
 
 ![Overview tab — the Open on GitHub button, stars and forks, and contributors for the selected repo](/screenshot-detail-overview.png)
 
@@ -113,7 +113,7 @@ Both tabs share the same row shape:
 
 Click anywhere on a row to open the issue or PR on github.com. Each tab's header has a **New Issue / New Pull Request** button (opens the corresponding "new" page), an **Open on GitHub** button (opens the full Issues / Pull Requests list page — the label follows the remote's host), and a **Refresh** button that bypasses the 60-second cache when you want fresh data.
 
-Both tabs need either a working `gh` CLI (see [GitHub Integration](/docs/github-integration)) or a Personal Access Token in Settings; on repos with no recognised GitHub remote (or no remote at all), the tabs show a short explanation instead of an empty list.
+On GitHub repos both tabs need either a working `gh` CLI (see [GitHub Integration](/docs/github-integration)) or a Personal Access Token in Settings. On Codeberg they need nothing — its API answers anonymously. For a repo with no remote, or one on GitLab or Bitbucket, the tabs show a short explanation instead of an empty list.
 
 ![Issues tab — green open-issue icon, number, title, labels, author avatar, with New Issue, Open on GitHub, and Refresh in the header](/screenshot-detail-issues.png)
 

--- a/content/detail-panel.mdx
+++ b/content/detail-panel.mdx
@@ -34,11 +34,11 @@ Because the bar is docked outside the scroll area, the actions stay reachable fr
 
 ## Overview
 
-The Overview tab paints the GitHub-side identity of the repo:
+The Overview tab paints the forge-side identity of the repo — GitHub or Codeberg; see [GitHub Integration → Codeberg](/docs/github-integration#codeberg) for what each one can fill in:
 
 - An **Open on GitHub** button — opens the repo's page in your browser. The label follows the remote's host (GitHub, GitLab, Bitbucket, or Codeberg) and it appears for any repo with a recognized remote, even before the rest of the metadata loads.
 - **Description** at the top
-- A row of stat pills: ★ stars · ⎇ forks · 🏷 latest release · 🔗 homepage. Stars and forks are read-only; the release tag opens the GitHub release page in your browser, and the homepage pill opens the configured homepage URL.
+- A row of stat pills: ★ stars · ⎇ forks · 🏷 latest release · 🔗 homepage. Stars and forks are read-only; the release tag opens the release page on the repo's own forge, and the homepage pill opens the configured homepage URL.
 - **Topic chips** (wrapping onto multiple lines when there are many)
 - **Top contributors** — up to eight avatars, click an avatar to open that user's GitHub profile
 

--- a/content/detail-panel.mdx
+++ b/content/detail-panel.mdx
@@ -36,7 +36,7 @@ Because the bar is docked outside the scroll area, the actions stay reachable fr
 
 The Overview tab paints the GitHub-side identity of the repo:
 
-- An **Open on GitHub** button — opens the repo's page in your browser. The label follows the remote's host (GitHub, GitLab, or Bitbucket) and it appears for any repo with a recognized remote, even before the rest of the metadata loads.
+- An **Open on GitHub** button — opens the repo's page in your browser. The label follows the remote's host (GitHub, GitLab, Bitbucket, or Codeberg) and it appears for any repo with a recognized remote, even before the rest of the metadata loads.
 - **Description** at the top
 - A row of stat pills: ★ stars · ⎇ forks · 🏷 latest release · 🔗 homepage. Stars and forks are read-only; the release tag opens the GitHub release page in your browser, and the homepage pill opens the configured homepage URL.
 - **Topic chips** (wrapping onto multiple lines when there are many)

--- a/content/file-browser.mdx
+++ b/content/file-browser.mdx
@@ -114,7 +114,7 @@ Big numbers use the compact format (`1.2K` instead of `1234`). Sort by Stars to 
 
 ![File browser with Issues, PRs and Stars columns populated for a folder of Mantine extensions](/screenshot-hero.png)
 
-The columns only populate for repos with a recognised GitHub remote. Local-only repos, GitLab and Bitbucket remotes leave the cells empty rather than showing a placeholder dash on every row.
+The columns populate for repos on **GitHub** and **Codeberg**. Codeberg needs no setup at all — it answers anonymously, so the numbers appear whether or not you have connected a GitHub account. Local-only repos, and repos on GitLab or Bitbucket, leave the cells empty rather than showing a placeholder dash on every row.
 
 See [GitHub Integration](/docs/github-integration) for how to enable these columns (either via the `gh` CLI or a Personal Access Token).
 
@@ -157,7 +157,7 @@ Grab the **icon** of any file or folder and drop it anywhere that accepts a file
 
 Right-click any item in the tree to get a context-sensitive menu with inline SF Symbol icons. On a single item the menu adapts to what you right-clicked:
 
-- **Repository folder** — Open in Finder / Terminal, Add to Root Folders, Quick Look, Get Info, Duplicate, Copy / Copy Path, Fetch / Pull / Push, **Open on GitHub** (or GitLab / Bitbucket — the label follows the remote's host; shown only when the repo has a recognized remote), Stage All, Move to Trash
+- **Repository folder** — Open in Finder / Terminal, Add to Root Folders, Quick Look, Get Info, Duplicate, Copy / Copy Path, Fetch / Pull / Push, **Open on GitHub** (or GitLab / Bitbucket / Codeberg — the label follows the remote's host; shown only when the repo has a recognized remote), Stage All, Move to Trash
 - **File inside a repo** — Open, Quick Look, Reveal in Finder, Get Info, Duplicate, Copy / Copy Path, Stage / Unstage (when applicable), Move to Trash
 
 ![Context menu on a repository folder](/screenshot-context-menu.png)

--- a/content/file-browser.mdx
+++ b/content/file-browser.mdx
@@ -116,7 +116,7 @@ Big numbers use the compact format (`1.2K` instead of `1234`). Sort by Stars to 
 
 The columns populate for repos on **GitHub** and **Codeberg**. Codeberg needs no setup at all — it answers anonymously, so the numbers appear whether or not you have connected a GitHub account. Local-only repos, and repos on GitLab or Bitbucket, leave the cells empty rather than showing a placeholder dash on every row.
 
-See [GitHub Integration](/docs/github-integration) for how to enable these columns (either via the `gh` CLI or a Personal Access Token).
+For **GitHub** repos the columns need credentials — see [GitHub Integration](/docs/github-integration) for the `gh` CLI or Personal Access Token setup. Codeberg repos need none of that; they populate on their own.
 
 ## Size column
 

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -84,7 +84,7 @@ You can add multiple root folders. Each one appears in the sidebar and can be se
 FinderGit opens on the **[Repository List](/docs/repository-list)** — a flat, sortable table of every repository you track. The window has four areas:
 
 ### Sidebar (left)
-The control panel. It's organized into **Dashboards** (Overview, Account), **Library** (All Repositories, Favorites, Recents), **Smart Views** (Changes, Ahead, Behind, Dirty, Clean — status filters with live counts), **Filters** (GitHub, GitLab, Bitbucket, Local Only), and **Root Folders** (the directories you scan, and the groups you organize them into). Picking an entry changes what the main area shows. See [Repository List → The sidebar](/docs/repository-list#the-sidebar).
+The control panel. It's organized into **Dashboards** (Overview, Account), **Library** (All Repositories, Favorites, Recents), **Smart Views** (Changes, Ahead, Behind, Dirty, Clean — status filters with live counts), **Filters** (GitHub, GitLab, Bitbucket, Codeberg, Local Only), and **Root Folders** (the directories you scan, and the groups you organize them into). Picking an entry changes what the main area shows. See [Repository List → The sidebar](/docs/repository-list#the-sidebar).
 
 ### Main area (center)
 Either the **Repository List** — one sortable row per repo (Repository, Branch, Status, Ahead/Behind, Files, Size) — or, when you select a Root Folder (or double-click a repo), the Finder-style **[File Browser](/docs/file-browser)** tree.

--- a/content/github-integration.mdx
+++ b/content/github-integration.mdx
@@ -61,7 +61,7 @@ Once stored, the token lives in the Keychain under the entry for `github.com`. U
 
 ### Issues tab
 
-Open issues for the repo, with state icon, number, title, labels, and author avatar. Click any row to open the issue on GitHub.com. The **New Issue** button opens the new-issue form, and **Open on GitHub** opens the full Issues page in your browser (the label follows the remote's host — GitHub, GitLab, Bitbucket, or Codeberg).
+Open issues for the repo, with state icon, number, title, labels, and author avatar. Click any row to open the issue on the forge it lives on. The **New Issue** button opens the new-issue form, and **Open on GitHub** opens the full Issues page in your browser (the label follows the remote's host — GitHub, GitLab, Bitbucket, or Codeberg).
 
 ![Issues tab populated on a Mantine extension repo](/screenshot-detail-issues.png)
 
@@ -138,7 +138,7 @@ Each tab has a **Refresh** button that bypasses the cache when you want immediat
 
 - All requests go directly to `api.github.com` from your Mac. FinderGit runs no proxy and stores no telemetry about the repos you open.
 - With `gh` CLI auth or a PAT, you get GitHub's authenticated rate limit (5000 requests/hour) — comfortably above what FinderGit consumes.
-- Unauthenticated traffic is *not* attempted; if neither `gh` nor a PAT is set up, FinderGit shows an empty state instead of hitting the 60-request/hour anonymous limit.
+- Unauthenticated traffic to GitHub is *not* attempted; if neither `gh` nor a PAT is set up, FinderGit shows an empty state instead of hitting the 60-request/hour anonymous limit. (Codeberg is the exception, and by design — its API answers anonymously, so requests there carry no credentials at all. See [Codeberg](#codeberg).)
 
 ## Codeberg
 

--- a/content/github-integration.mdx
+++ b/content/github-integration.mdx
@@ -21,7 +21,7 @@ There are two ways to authenticate, and FinderGit picks the right one automatica
 1. **GitHub CLI (`gh`)** — preferred. If you already use `gh` and have run `gh auth login`, FinderGit inherits that authentication and you don't need to manage a token.
 2. **Personal Access Token (PAT)** — fallback. If `gh` isn't installed or isn't authenticated, FinderGit reads a token you've pasted into Settings (stored in the macOS Keychain, never on disk in FinderGit's own files).
 
-If neither is configured, the GitHub-driven tabs and columns degrade gracefully: a short hint replaces the empty list, and the rest of FinderGit keeps working.
+If neither is configured, the tabs and columns for **GitHub** repos degrade gracefully: a short hint replaces the empty list, and the rest of FinderGit keeps working. Codeberg repos are unaffected — they need no credentials in the first place.
 
 ### Option 1: `gh` CLI (recommended)
 

--- a/content/github-integration.mdx
+++ b/content/github-integration.mdx
@@ -61,7 +61,7 @@ Once stored, the token lives in the Keychain under the entry for `github.com`. U
 
 ### Issues tab
 
-Open issues for the repo, with state icon, number, title, labels, and author avatar. Click any row to open the issue on GitHub.com. The **New Issue** button opens the new-issue form, and **Open on GitHub** opens the full Issues page in your browser (the label follows the remote's host — GitHub, GitLab, or Bitbucket).
+Open issues for the repo, with state icon, number, title, labels, and author avatar. Click any row to open the issue on GitHub.com. The **New Issue** button opens the new-issue form, and **Open on GitHub** opens the full Issues page in your browser (the label follows the remote's host — GitHub, GitLab, Bitbucket, or Codeberg).
 
 ![Issues tab populated on a Mantine extension repo](/screenshot-detail-issues.png)
 
@@ -81,7 +81,7 @@ In the table, three columns appear next to **Changes**:
 
 Numbers use the compact format (`1.2K` instead of `1234`). Click any column header to sort by it — popular repos to the top, or busiest repos by open issues.
 
-For repos without a GitHub remote (local-only, or pointing at GitLab / Bitbucket), the cells stay empty. GitLab and Bitbucket integration is a planned follow-up.
+Codeberg repos fill these in too — see [Codeberg](#codeberg) below. For repos that are local-only or point at GitLab / Bitbucket, the cells stay empty; integration for those two is a planned follow-up.
 
 ## Fork awareness
 
@@ -139,3 +139,27 @@ Each tab has a **Refresh** button that bypasses the cache when you want immediat
 - All requests go directly to `api.github.com` from your Mac. FinderGit runs no proxy and stores no telemetry about the repos you open.
 - With `gh` CLI auth or a PAT, you get GitHub's authenticated rate limit (5000 requests/hour) — comfortably above what FinderGit consumes.
 - Unauthenticated traffic is *not* attempted; if neither `gh` nor a PAT is set up, FinderGit shows an empty state instead of hitting the 60-request/hour anonymous limit.
+
+## Codeberg
+
+Codeberg repos are enriched too, and unlike GitHub they need **no setup at all** — no account to connect, no token to paste. Codeberg runs [Forgejo](https://forgejo.org), whose API answers anonymous requests, so the moment FinderGit recognises a `codeberg.org` remote it can fill in the numbers.
+
+What works on a Codeberg repo:
+
+- The **Issues** and **Pull Requests** tabs, with labels, authors and state.
+- The **file-browser columns** — stars, open issues, open pull requests.
+- **Overview** metadata: description, stars, forks, topics, website, and the latest release.
+- The **fork badge** and its parent repository.
+- The sidebar **Codeberg** filter, and **Open on Codeberg** in the context menu.
+
+What does not, and why:
+
+| Not available | Reason |
+|---|---|
+| Contributor list in Overview | Forgejo has no public contributors endpoint |
+| "N behind" and **Sync Fork** | Comparing across two repositories is not something the API can answer, and there is no server-side fork sync to offer |
+| Forge status panel | Codeberg publishes its status through Uptime Kuma rather than the platform the panel reads; a link with no numbers behind it would be worse than none |
+| Account dashboard, Clone window | Both describe *your* account, which needs credentials Codeberg is not being asked for |
+
+GitLab and Bitbucket remain browse-only: FinderGit recognises their remotes, filters by them and opens them in a browser, but does not read their APIs. Their repos show empty columns rather than borrowed numbers.
+

--- a/content/github-integration.mdx
+++ b/content/github-integration.mdx
@@ -157,7 +157,7 @@ What does not, and why:
 | Not available | Reason |
 |---|---|
 | Contributor list in Overview | Forgejo has no public contributors endpoint |
-| "N behind" and **Sync Fork** | Comparing across two repositories is not something the API can answer, and there is no server-side fork sync to offer |
+| "N behind" and **Sync Fork** | Both need an account. Forgejo *can* sync a fork and *can* report how far behind one is — it just won't tell an anonymous caller, and FinderGit has nowhere to sign in to Codeberg yet. A count we can't trust would badge a stale fork as up to date, so it shows nothing instead |
 | Forge status panel | Codeberg publishes its status through Uptime Kuma rather than the platform the panel reads; a link with no numbers behind it would be worse than none |
 | Account dashboard, Clone window | Both describe *your* account, which needs credentials Codeberg is not being asked for |
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -10,7 +10,7 @@ description: "FinderGit documentation — get started with the native macOS Git-
 
 ## What it does
 
-- **Repository portfolio** — every repo you track in one flat, sortable table (branch, status, ahead/behind, files, size), sliced by **Smart Views** (Changes · Ahead · Behind · Dirty · Clean) and remote **Filters** (GitHub · GitLab · Bitbucket · Local Only), with Favorites, Recents, and a live summary bar (see [Repository List](/docs/repository-list))
+- **Repository portfolio** — every repo you track in one flat, sortable table (branch, status, ahead/behind, files, size), sliced by **Smart Views** (Changes · Ahead · Behind · Dirty · Clean) and remote **Filters** (GitHub · GitLab · Bitbucket · Codeberg · Local Only), with Favorites, Recents, and a live summary bar (see [Repository List](/docs/repository-list))
 - **Tree view with sortable columns** — drill into any root folder like Finder's list view, with columns for Branch, Status, Size, and Date Modified — plus GitHub-driven columns for Issues, PRs, and Stars on repos with a GitHub remote
 - **Live Git status** — every repository shows its current branch, clean/dirty/unpushed state, updated in real time via FSEvents
 - **Ahead/behind counter** — the status badge shows `↑N`, `↓N`, or `↑N ↓M` with tooltips so you can spot repos that need a push, a pull, or both without opening them

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -11,7 +11,7 @@ description: "FinderGit documentation — get started with the native macOS Git-
 ## What it does
 
 - **Repository portfolio** — every repo you track in one flat, sortable table (branch, status, ahead/behind, files, size), sliced by **Smart Views** (Changes · Ahead · Behind · Dirty · Clean) and remote **Filters** (GitHub · GitLab · Bitbucket · Codeberg · Local Only), with Favorites, Recents, and a live summary bar (see [Repository List](/docs/repository-list))
-- **Tree view with sortable columns** — drill into any root folder like Finder's list view, with columns for Branch, Status, Size, and Date Modified — plus GitHub-driven columns for Issues, PRs, and Stars on repos with a GitHub remote
+- **Tree view with sortable columns** — drill into any root folder like Finder's list view, with columns for Branch, Status, Size, and Date Modified — plus live columns for Issues, PRs, and Stars on repos hosted on GitHub or Codeberg
 - **Live Git status** — every repository shows its current branch, clean/dirty/unpushed state, updated in real time via FSEvents
 - **Ahead/behind counter** — the status badge shows `↑N`, `↓N`, or `↑N ↓M` with tooltips so you can spot repos that need a push, a pull, or both without opening them
 - **Auto-fetch** — optional background `git fetch` at a user-chosen interval so the ahead/behind counter stays fresh without manual refreshes

--- a/content/repository-list.mdx
+++ b/content/repository-list.mdx
@@ -46,7 +46,7 @@ Group the list by where each repository's `origin` remote points:
 - **GitHub**, **GitLab**, **Bitbucket**, **Codeberg** — recognized from the remote URL.
 - **Local Only** — repositories with no recognized remote.
 
-> Live GitHub data (Issues, PRs, Stars, fork status) is populated for GitHub remotes only; GitLab and Bitbucket are recognized for grouping and "Open on…" links. See [GitHub Integration](/docs/github-integration).
+> Live forge data (Issues, PRs, Stars, fork status) is populated for **GitHub** and **Codeberg** remotes — Codeberg with no setup at all, since its API answers anonymously. **GitLab** and **Bitbucket** are recognized for grouping and "Open on…" links, and leave those columns empty. See [GitHub Integration](/docs/github-integration).
 
 ### Root Folders
 

--- a/content/repository-list.mdx
+++ b/content/repository-list.mdx
@@ -43,7 +43,7 @@ Dynamic, status-driven filters — each shows a running count and updates in rea
 
 Group the list by where each repository's `origin` remote points:
 
-- **GitHub**, **GitLab**, **Bitbucket** — recognized from the remote URL.
+- **GitHub**, **GitLab**, **Bitbucket**, **Codeberg** — recognized from the remote URL.
 - **Local Only** — repositories with no recognized remote.
 
 > Live GitHub data (Issues, PRs, Stars, fork status) is populated for GitHub remotes only; GitLab and Bitbucket are recognized for grouping and "Open on…" links. See [GitHub Integration](/docs/github-integration).


### PR DESCRIPTION
Documentation for the Codeberg support built in the app repo, for issue #42.

## ⚠️ Do not merge yet

These pages describe behaviour **no released build has**. Merging deploys them, and the site would be promising a feature nobody can use yet. This should land with — or just before — the release that ships it.

## What changed

Six files named the forges in their own words, so adding Codeberg to one page would have left the site contradicting itself:

| file | what it said |
|---|---|
| `index.mdx`, `getting-started.mdx`, `repository-list.mdx` | the Filters list |
| `detail-panel.mdx`, `file-browser.mdx` | the "Open on …" label follows the host |
| `github-integration.mdx` | the host list, and which repos get enriched |

Two of those changed meaning rather than gaining a word. `file-browser.mdx` said the columns "only populate for repos with a recognised GitHub remote" and that everything else stays empty — no longer true, and the interesting half is that Codeberg needs **no setup at all** to fill them, because Forgejo answers anonymously.

## The new section

`github-integration.mdx` gets a **Codeberg** section that is mostly about what does *not* work, with the reason for each — because these are properties of the engine, not a to-do list:

- no contributors endpoint, so no contributor list;
- no cross-repository compare, so no "N behind" and no fork sync;
- status published through Uptime Kuma, which the app cannot read, so no status panel;
- account dashboard and Clone window need credentials Codeberg is not being asked for.

It also states plainly that GitLab and Bitbucket stay browse-only and show empty columns rather than borrowed numbers — which, as of the app-side change, is now literally true rather than approximately.

Gate green: tsc, jest (25).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository and issue documentation to include Codeberg alongside GitHub-compatible hosts.
  * Clarified Codeberg support for repository filters, file-browser data columns, context-menu actions, and “Open on …” labels.
  * Added setup and feature-availability details for Codeberg API enrichment.
  * Documented that GitLab, Bitbucket, and local-only repositories have limited or unavailable enrichment features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->