### PR TITLE
docs(faq): Codeberg needs no account, and the FAQ said otherwise

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -59,11 +59,14 @@ const faqItems: { value: string; question: string; answer: ReactNode }[] = [
         dashboard, the issue / pull-request / star counts in the file browser, and new-star alerts.
         FinderGit reuses the GitHub CLI if it&apos;s already set up, or a personal access token you
         paste into Settings — kept in your Keychain, never written to disk. Plain browsing, Git
-        status, diffs and commit / push / pull all work with no GitHub connection at all. See{' '}
+        status, diffs and commit / push / pull all work with no GitHub connection at all.{' '}
+        <strong>Codeberg repositories need nothing at all</strong> — their issue, pull-request and
+        star counts fill in without an account or a token, because Codeberg answers questions about
+        public repositories anonymously. See{' '}
         <Anchor href="/docs/github-integration" size="sm">
           GitHub Integration
         </Anchor>{' '}
-        for setup.
+        for GitHub setup and what Codeberg covers.
       </>
     ),
   },


### PR DESCRIPTION
Post-release gap, found by grepping the **components** rather than trusting that the docs pass had covered everything.

`release.sh` auto-includes `content/` in the release commit — it does not include `components/`. So the docs pages describe Codeberg correctly, while the FAQ on the homepage still answered "Do I need to connect a GitHub account?" as if every forge required one:

> Only for the GitHub-powered extras — the Account dashboard, the issue / pull-request / star counts in the file browser, and new-star alerts.

Since 0.27.0 that is wrong for Codeberg, and wrong about the exact thing that makes the release worth having: those counts appear there with no account and no token at all.

Checked the rest of the surface in the same pass — `config.app.version` is at 0.27.0 (bumped by the pipeline), the homepage carries no forge list to extend, and no component other than this one names a forge.

Gate green: tsc, jest (25).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub account FAQ to clarify that public Codeberg repository metadata requires no account or token.
  * Clarified that the GitHub Integration guide includes both GitHub setup and Codeberg functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->