### PR TITLE
ci: watch the AI commit health endpoint

### DIFF
--- a/.github/workflows/ai-commit-health.yml
+++ b/.github/workflows/ai-commit-health.yml
@@ -1,0 +1,65 @@
+# Watches the AI commit-message endpoint's health check.
+#
+# WHY THIS EXISTS. Groq decommissioned the model the proxy asked for on
+# 2026-08-16. Every request failed from that moment, the app reported "the AI
+# provider is temporarily unreachable" — advice to wait, for something that
+# would never recover — and we found out from a user on the 24th. Groq had
+# emailed the deprecation notice two months earlier. Nothing was watching, so
+# nothing knew. (FinderGit#154, FinderGit#156.)
+#
+# The health route answers 200 only when the configured model is one the
+# provider will actually serve, so a non-2xx here means the feature is down.
+# It costs no tokens from the shared per-minute allowance: it asks for the
+# model list, never a completion.
+
+name: AI commit health
+
+on:
+  schedule:
+    # Every 30 minutes. The goal is "we know the same day", so the interval is
+    # not the point — having any at all is. Note GitHub disables scheduled
+    # workflows after 60 days without repository activity; this repo gets a
+    # commit on every release, so that has not been an issue, but a long quiet
+    # spell would silently stop the watch.
+    - cron: '*/30 * * * *'
+  # So a failure can be re-checked by hand without waiting for the next tick.
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ask the health route
+        run: |
+          set -euo pipefail
+
+          # `code`, not `status`: the latter is read-only in zsh, so pasting
+          # this into a terminal to debug the check fails instead of answering.
+          # -f makes curl exit non-zero on any 4xx/5xx, which is what turns a
+          # broken endpoint into a failed run and therefore an email. The body
+          # is captured either way: on failure its `reason` field says which
+          # half broke, and reading it here saves opening the endpoint by hand.
+          code=$(curl -s -o body.json -w '%{http_code}' \
+            --max-time 30 \
+            -H 'Accept: application/json' \
+            "https://findergit.app/api/ai-commit/health") || true
+
+          echo "HTTP $code"
+          echo "body: $(cat body.json)"
+
+          if [ "$code" != "200" ]; then
+            echo "::error::AI commit health check failed (HTTP $code): $(cat body.json)"
+            echo "reason values: missing_api_key | invalid_api_key | model_unavailable | upstream_error | upstream_unreachable"
+            exit 1
+          fi
+
+          # A 200 with ok:false should not exist, but assert it rather than
+          # trusting the status alone: the whole point of this file is not
+          # taking a green signal on faith.
+          if ! grep -q '"ok":true' body.json; then
+            echo "::error::HTTP 200 but the payload is not ok:true — $(cat body.json)"
+            exit 1
+          fi
+
+          echo "AI commit endpoint healthy: $(cat body.json)"


### PR DESCRIPTION
Closes gfazioli/FinderGit#156 — the half of the AI-commit outage that was never fixed.

Groq decommissioned the model on 2026-08-16, every request failed from that moment, and we found out from a user on the 24th. The deprecation email had arrived two months earlier. The fix shipped the same day it was reported; **nothing was watching**, and that part stayed open.

## What it does

A scheduled `curl` against `/api/ai-commit/health` every 30 minutes. That route answers 200 only when the configured model is one the provider will actually serve, and it costs **no tokens** from the per-minute allowance the whole user base shares — it asks for the model list, never a completion.

A non-2xx fails the run, which is what makes GitHub send mail on a scheduled workflow. The body is echoed either way, because its `reason` field says which half broke (`missing_api_key`, `invalid_api_key`, `model_unavailable`, `upstream_error`, `upstream_unreachable`).

## Verified both directions

A monitor that cannot go red is decoration, so I checked both:

```
GET /api/ai-commit/health            → HTTP 200 {"ok":true,"model":"openai/gpt-oss-120b"}  → job passes
GET /api/ai-commit/health-does-not-exist → HTTP 404                                        → job fails
```

There is also an assertion on `ok:true` even after a 200, rather than trusting the status alone — the entire point of the file is not taking a green signal on faith.

## Two notes in the file itself

- The variable is `code`, not `status`: `status` is read-only in zsh, so pasting the snippet into a terminal to debug the check would fail instead of answering.
- GitHub disables scheduled workflows after 60 days of repository inactivity. This repo gets a commit on every release so it has not mattered, but a quiet spell would stop the watch silently — worth knowing rather than discovering.

First workflow in either repo, so nothing to conflict with.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Added automated health checks for the AI commit service every 30 minutes.
  * Added support for manually running health checks on demand.
  * Health checks now report response details and flag unsuccessful or invalid responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->