### PR TITLE
ci: check the AI endpoint once a day

### DIFF
--- a/.github/workflows/ai-commit-health.yml
+++ b/.github/workflows/ai-commit-health.yml
@@ -16,12 +16,23 @@ name: AI commit health
 
 on:
   schedule:
-    # Every 30 minutes. The goal is "we know the same day", so the interval is
-    # not the point — having any at all is. Note GitHub disables scheduled
-    # workflows after 60 days without repository activity; this repo gets a
-    # commit on every release, so that has not been an issue, but a long quiet
-    # spell would silently stop the watch.
-    - cron: '*/30 * * * *'
+    # Once a day, early morning UTC, so a failure is waiting at the start of
+    # the day rather than arriving mid-afternoon.
+    #
+    # The interval was never the point: the outage this exists for lasted
+    # EIGHT DAYS and was reported by a user. Going from that to "by tomorrow
+    # morning" is the whole win; going from a day to half an hour buys back
+    # hours on a failure mode that takes weeks to appear, at the cost of 48
+    # upstream calls a day. Raise it again if the feature ever becomes
+    # something people depend on hour to hour.
+    #
+    # Two things worth knowing about a once-a-day schedule specifically:
+    # GitHub delays scheduled runs under load, and with a single daily tick a
+    # delay is the whole signal rather than a fraction of it — so treat the
+    # run time as approximate. And GitHub disables scheduled workflows after
+    # 60 days without repository activity; this repo gets a commit on every
+    # release, but a long quiet spell would stop the watch silently.
+    - cron: '0 6 * * *'
   # So a failure can be re-checked by hand without waiting for the next tick.
   workflow_dispatch:
 


### PR DESCRIPTION
Drops the AI-commit health check from every 30 minutes to once a day at 06:00 UTC (08:00 Italian summer time), as requested.

**Why this is not a downgrade.** The outage this watch exists for lasted **eight days** and reached us through a user. The value is in going from that to "by tomorrow morning at the latest" — the difference between a day and half an hour is hours, on a failure mode that appears every few months when a provider retires a model. Half-hourly also meant 48 upstream calls a day for a check whose answer changes at most a handful of times a year.

**06:00 UTC** so that if it fails, the mail is waiting at the start of the day rather than arriving mid-afternoon.

**One caveat now written into the file**, because it matters far more with one tick than with 48: GitHub delays scheduled runs under load, sometimes by a long while. With a single daily run that delay *is* the signal rather than a fraction of it — so the run time should be read as approximate, not as a clock. (The existing note about GitHub disabling scheduled workflows after 60 days of repository inactivity still applies, and matters for the same reason.)

`workflow_dispatch` is unchanged, so the check can still be run by hand at any time from the Actions tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated commit health check to run once daily at 06:00 UTC instead of every 30 minutes.
  * Added guidance explaining potential scheduling delays and workflow deactivation after extended repository inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->